### PR TITLE
Disable Github workflow on branches

### DIFF
--- a/.github/workflows/branch-validations.yaml
+++ b/.github/workflows/branch-validations.yaml
@@ -3,9 +3,9 @@ name: Validations
 on:
   push:
     branches:
-      - '*'
+      - '**'
     tags-ignore:
-      - '*'
+      - '**'
 
 jobs:
   security-checks:

--- a/.github/workflows/tag-validations-and-release.yaml
+++ b/.github/workflows/tag-validations-and-release.yaml
@@ -1,11 +1,11 @@
 name: Validate Tag
 
 on:
-  create:
+  push:
     tags:
-      - '*'
-    branch-ignore:
-      - '*'
+      - '**'
+    branches-ignore:
+      - '**'
 
 env:
   BOOTSTRAP_ENDPOINT: https://main.test.croct.tech/client/web/bootstrap


### PR DESCRIPTION
Prior to this change, the workflow intended to prepare new releases from tags were being executed every time a branch was created

This change sets the new release workflow to be triggered on `push` events ignoring all branch references. As it turns out, it is not possible at the moment to filter the origin of `create` events.

References:
- https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags