### PR TITLE
Change Github Actions jobs to run in parallel

### DIFF
--- a/.github/workflows/branch-validations.yaml
+++ b/.github/workflows/branch-validations.yaml
@@ -50,9 +50,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-18.04
-    needs:
-      - security-checks
-      - validate
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -73,9 +70,6 @@ jobs:
 
   test:
     runs-on: ubuntu-18.04
-    needs:
-      - security-checks
-      - validate
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/tag-validations-and-release.yaml
+++ b/.github/workflows/tag-validations-and-release.yaml
@@ -55,9 +55,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-18.04
-    needs:
-      - security-checks
-      - validate
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -78,9 +75,6 @@ jobs:
 
   test:
     runs-on: ubuntu-18.04
-    needs:
-      - security-checks
-      - validate
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Prior to this change, the `lint` and `test` jobs were executed only after the typescript validations and security checks succeeded.

This change sets all of them to run in parallel from at the start of the workflow.