### PR TITLE
Increase length limit for metadata values from 100 to 300 characters

### DIFF
--- a/src/schema/sdkSchemas.ts
+++ b/src/schema/sdkSchemas.ts
@@ -13,7 +13,7 @@ export const eventMetadataSchema = new ObjectType({
         format: 'identifier',
     }),
     additionalProperties: new StringType({
-        maxLength: 100,
+        maxLength: 300,
     }),
 });
 

--- a/test/schemas/sdkSchemas.test.ts
+++ b/test/schemas/sdkSchemas.test.ts
@@ -5,8 +5,7 @@ describe('The event metadata schema', () => {
         [{}],
         [{
             foo: 'bar',
-            _keyWith20Characters: 'stringValueWith100Characters______________'
-                + '__________________________________________________________',
+            _keyWith20Characters: 'x'.repeat(300),
             thirdKey: 'someValue',
             fourthKey: 'someValue',
             fifthKey: 'someValue',
@@ -34,10 +33,9 @@ describe('The event metadata schema', () => {
         ],
         [
             {
-                longValue: 'stringValueWith101Characters____________________'
-                    + '_____________________________________________________',
+                longValue: 'x'.repeat(301),
             },
-            'Expected at most 100 characters at path \'/longValue\', actual 101.',
+            'Expected at most 300 characters at path \'/longValue\', actual 301.',
         ],
         [
             {


### PR DESCRIPTION
## Summary
Increase length limit for metadata values from 100 to 300 characters.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings