### PR TITLE
Renames "batch" callback to "flushed" and exposes in tracker facade

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -230,7 +230,7 @@ export class Container {
 
             this.tracker.suspend();
 
-            await this.tracker.batch;
+            await this.tracker.flushed;
         }
 
         delete this.context;

--- a/src/facade/trackerFacade.ts
+++ b/src/facade/trackerFacade.ts
@@ -58,6 +58,10 @@ export default class TrackerFacade {
         this.tracker = tracker;
     }
 
+    public get flushed(): Promise<void> {
+        return this.tracker.flushed;
+    }
+
     public enable(): void {
         this.tracker.enable();
     }

--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -75,7 +75,7 @@ export default class Tracker {
         this.trackInactivity = this.trackInactivity.bind(this);
     }
 
-    public get batch(): Promise<void> {
+    public get flushed(): Promise<void> {
         const suppress = (): void => {
             // suppress errors
         };

--- a/test/facade/trackerFacade.test.ts
+++ b/test/facade/trackerFacade.test.ts
@@ -27,6 +27,21 @@ describe('A tracker facade', () => {
         expect(tracker.disable).toHaveBeenCalledTimes(1);
     });
 
+    test('should provide a callback that is called when the current pending events are flushed', async () => {
+        const tracker = jest.genMockFromModule<Tracker>('../../src/tracker');
+        const batch = jest.fn().mockResolvedValue(undefined);
+
+        Object.defineProperty(tracker, 'flushed', {
+            get: batch,
+        });
+
+        const trackerFacade = new TrackerFacade(tracker);
+
+        await expect(trackerFacade.flushed).resolves.toBeUndefined();
+
+        expect(batch).toHaveBeenCalledTimes(1);
+    });
+
     test.each<ExternalEvent[]>([
         [
             {

--- a/test/tracker.test.ts
+++ b/test/tracker.test.ts
@@ -1071,7 +1071,7 @@ describe('A tracker', () => {
         expect(channel.publish).toHaveBeenCalledTimes(1);
     });
 
-    test('should provide a callback that is called when the current event batch is processed', async () => {
+    test('should provide a callback that is called when the current pending events are flushed', async () => {
         const publish = jest.fn(event => new Promise<any>(resolve => setTimeout(() => resolve(event), 10)));
 
         const channel: OutputChannel<Beacon> = {
@@ -1087,7 +1087,7 @@ describe('A tracker', () => {
             channel: channel,
         });
 
-        await expect(tracker.batch).resolves.toBeUndefined();
+        await expect(tracker.flushed).resolves.toBeUndefined();
 
         const event: Event = {
             type: 'nothingChanged',
@@ -1096,7 +1096,7 @@ describe('A tracker', () => {
 
         const promise = tracker.track(event);
 
-        await expect(tracker.batch).resolves.toBeUndefined();
+        await expect(tracker.flushed).resolves.toBeUndefined();
 
         expect(publish).toBeCalledWith({
             timestamp: now,


### PR DESCRIPTION
## Summary
Renames `batch` callback to `flushed` and exposes it in tracker facade

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings