### PR TITLE
Change build to use production endpoints

### DIFF
--- a/.github/workflows/deploy-published-releases.yaml
+++ b/.github/workflows/deploy-published-releases.yaml
@@ -6,9 +6,9 @@ on:
       - published
 
 env:
-  BOOTSTRAP_ENDPOINT: https://main.test.croct.tech/client/web/bootstrap
-  TRACKER_ENDPOINT: wss://main.test.croct.tech/client/web/connect
-  EVALUATION_ENDPOINT: https://main.test.croct.tech/client/web/evaluate
+  BOOTSTRAP_ENDPOINT: https://api.croct.io/client/web/bootstrap
+  TRACKER_ENDPOINT: wss://api.croct.io/client/web/connect
+  EVALUATION_ENDPOINT: https://api.croct.io/client/web/evaluate
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
This changes the build job on the release pipeline to use the production endpoints at croct.io instead of test endpoints from main.test.croct.tech
