### PR TITLE
Add support for specifying subnamespaces for loggers

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -183,8 +183,8 @@ export class Container {
         );
     }
 
-    public getLogger(namespace?: string): Logger {
-        const prefix = `Croct${namespace === undefined ? '' : `:${namespace}`}`;
+    public getLogger(...namespace: string[]): Logger {
+        const prefix = `Croct${namespace.length === 0 ? '' : `:${namespace.join(':')}`}`;
 
         if (this.configuration.logger !== undefined) {
             return new NamespacedLogger(this.configuration.logger, prefix);

--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -154,8 +154,8 @@ export default class SdkFacade {
         return this.evaluator.evaluate(expression, options);
     }
 
-    public getLogger(namespace?: string): Logger {
-        return this.sdk.getLogger(namespace);
+    public getLogger(...namespace: string[]): Logger {
+        return this.sdk.getLogger(...namespace);
     }
 
     public close(): Promise<void> {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -108,8 +108,8 @@ export default class Sdk {
         return this.container.getEvaluator();
     }
 
-    public getLogger(namespace?: string): Logger {
-        return this.container.getLogger(namespace);
+    public getLogger(...namespace: string[]): Logger {
+        return this.container.getLogger(...namespace);
     }
 
     public async close(): Promise<void> {

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -140,17 +140,17 @@ test('should provide loggers that logs to the console in debug mode', () => {
     expect(warn).toHaveBeenCalledWith('[Croct]', 'Warn bar');
     expect(error).toHaveBeenCalledWith('[Croct]', 'Error bar');
 
-    const namespacedLogger = container.getLogger('Foo');
+    const namespacedLogger = container.getLogger('Foo', 'Bar');
 
     namespacedLogger.info('Info bar');
     namespacedLogger.debug('Debug bar');
     namespacedLogger.warn('Warn bar');
     namespacedLogger.error('Error bar');
 
-    expect(info).toHaveBeenLastCalledWith('[Croct:Foo]', 'Info bar');
-    expect(debug).toHaveBeenLastCalledWith('[Croct:Foo]', 'Debug bar');
-    expect(warn).toHaveBeenLastCalledWith('[Croct:Foo]', 'Warn bar');
-    expect(error).toHaveBeenLastCalledWith('[Croct:Foo]', 'Error bar');
+    expect(info).toHaveBeenLastCalledWith('[Croct:Foo:Bar]', 'Info bar');
+    expect(debug).toHaveBeenLastCalledWith('[Croct:Foo:Bar]', 'Debug bar');
+    expect(warn).toHaveBeenLastCalledWith('[Croct:Foo:Bar]', 'Warn bar');
+    expect(error).toHaveBeenLastCalledWith('[Croct:Foo:Bar]', 'Error bar');
 });
 
 test('should delegate logging to the provided logger', () => {

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -478,11 +478,11 @@ describe('A SDK facade', () => {
 
         sdkFacade.getLogger();
 
-        expect(getLogger).toHaveBeenLastCalledWith(undefined);
+        expect(getLogger).toHaveBeenCalledWith();
 
-        sdkFacade.getLogger('foo');
+        sdkFacade.getLogger('foo', 'bar');
 
-        expect(getLogger).toHaveBeenLastCalledWith('foo');
+        expect(getLogger).toHaveBeenLastCalledWith('foo', 'bar');
     });
 
     test('should close the SDK on close', async () => {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -66,17 +66,17 @@ describe('A SDK', () => {
             logger: logger,
         });
 
-        const namespacedLogger = sdk.getLogger('Foo');
+        const namespacedLogger = sdk.getLogger('Foo', 'Bar');
 
         namespacedLogger.info('Info bar');
         namespacedLogger.debug('Debug bar');
         namespacedLogger.warn('Warn bar');
         namespacedLogger.error('Error bar');
 
-        expect(logger.info).toHaveBeenLastCalledWith('[Croct:Foo] Info bar');
-        expect(logger.debug).toHaveBeenLastCalledWith('[Croct:Foo] Debug bar');
-        expect(logger.warn).toHaveBeenLastCalledWith('[Croct:Foo] Warn bar');
-        expect(logger.error).toHaveBeenLastCalledWith('[Croct:Foo] Error bar');
+        expect(logger.info).toHaveBeenLastCalledWith('[Croct:Foo:Bar] Info bar');
+        expect(logger.debug).toHaveBeenLastCalledWith('[Croct:Foo:Bar] Debug bar');
+        expect(logger.warn).toHaveBeenLastCalledWith('[Croct:Foo:Bar] Warn bar');
+        expect(logger.error).toHaveBeenLastCalledWith('[Croct:Foo:Bar] Error bar');
     });
 
     test('should configure the token storage with global scope', async () => {


### PR DESCRIPTION
## Summary
Add support for specifying subnamespaces for loggers.
### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings