### PR TITLE
Remove deprecated `cartId` field

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -28,7 +28,6 @@ export type CartItem = {
 }
 
 export type Cart = {
-    cartId?: string,
     currency: string,
     items: CartItem[],
     subtotal?: number,
@@ -53,7 +52,6 @@ export type OrderItem = {
 export type OrderStatus = 'placed' | 'paid' | 'completed';
 
 export type Order = {
-    cartId?: string,
     orderId: string,
     currency: string,
     items: OrderItem[],

--- a/src/schema/ecommerceSchemas.ts
+++ b/src/schema/ecommerceSchemas.ts
@@ -71,10 +71,6 @@ export const cartItem = new ObjectType({
 export const cart = new ObjectType({
     required: ['currency', 'items', 'total'],
     properties: {
-        cartId: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
         currency: new StringType({
             maxLength: 10,
             minLength: 1,
@@ -136,10 +132,6 @@ export const orderItem = new ObjectType({
 export const order = new ObjectType({
     required: ['orderId', 'currency', 'items', 'total'],
     properties: {
-        cartId: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
         orderId: new StringType({
             minLength: 1,
             maxLength: 50,

--- a/test/schemas/ecommerceSchemas.test.ts
+++ b/test/schemas/ecommerceSchemas.test.ts
@@ -264,7 +264,6 @@ describe('The cart schema', () => {
     test.each([
         [minimalCart],
         [{
-            cartId: 'f0b96546-be9c-4aa9-b672-64f0dcc57804',
             currency: 'brl',
             items: [
                 {
@@ -310,7 +309,6 @@ describe('The cart schema', () => {
     test.each([
         [
             {
-                cartId: 'f0b96546-be9c-4aa9-b672-64f0dcc57804',
                 total: 776.49,
                 items: [minimalCartItem],
             },
@@ -318,7 +316,6 @@ describe('The cart schema', () => {
         ],
         [
             {
-                cartId: 'f0b96546-be9c-4aa9-b672-64f0dcc57804',
                 currency: 'brl',
                 items: [minimalCartItem],
             },
@@ -326,29 +323,10 @@ describe('The cart schema', () => {
         ],
         [
             {
-                cartId: 'f0b96546-be9c-4aa9-b672-64f0dcc57804',
                 currency: 'brl',
                 total: 776.49,
             },
             'Missing property \'/items\'.',
-        ],
-        [
-            {
-                cartId: '',
-                currency: 'brl',
-                total: 776.49,
-                items: [minimalCartItem],
-            },
-            'Expected at least 1 character at path \'/cartId\', actual 0.',
-        ],
-        [
-            {
-                cartId: 'x'.repeat(51),
-                currency: 'brl',
-                total: 776.49,
-                items: [minimalCartItem],
-            },
-            'Expected at most 50 characters at path \'/cartId\', actual 51',
         ],
         [
             {
@@ -615,7 +593,6 @@ describe('The order schema', () => {
     test.each([
         [minimalOrder],
         [{
-            cartId: 'f0b96546-be9c-4aa9-b672-64f0dcc57804',
             orderId: 'b76c0ef6-9520-4107-9de3-11110829588e',
             currency: 'brl',
             items: [
@@ -715,26 +692,6 @@ describe('The order schema', () => {
                 total: 776.49,
             },
             'Missing property \'/items\'.',
-        ],
-        [
-            {
-                cartId: '',
-                orderId: 'b76c0ef6-9520-4107-9de3-11110829588e',
-                currency: 'brl',
-                total: 776.49,
-                items: [minimalOrderItem],
-            },
-            'Expected at least 1 character at path \'/cartId\', actual 0.',
-        ],
-        [
-            {
-                cartId: 'x'.repeat(51),
-                orderId: 'b76c0ef6-9520-4107-9de3-11110829588e',
-                currency: 'brl',
-                total: 776.49,
-                items: [minimalOrderItem],
-            },
-            'Expected at most 50 characters at path \'/cartId\', actual 51',
         ],
         [
             {


### PR DESCRIPTION
## Summary
Remove deprecated `cartId` field.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings