### PR TITLE
Deprecate event personalizationApplied in favor of eventOccurred

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -111,8 +111,8 @@ export const miscEventTypes = [
     'nothingChanged',
     'sessionAttributesChanged',
     'testGroupAssigned',
-    'personalizationApplied',
     'goalCompleted',
+    'eventOccurred',
 ] as const;
 
 export const eventTypes = [
@@ -293,14 +293,6 @@ export interface TestGroupAssigned extends AbstractEvent {
     groupId: string;
 }
 
-export interface PersonalizationApplied extends AbstractEvent {
-    type: 'personalizationApplied';
-    personalizationId: string;
-    audience?: string;
-    testId?: string;
-    groupId?: string;
-}
-
 export interface GoalCompleted extends AbstractEvent {
     type: 'goalCompleted';
     goalId: string;
@@ -308,11 +300,21 @@ export interface GoalCompleted extends AbstractEvent {
     currency?: string;
 }
 
+export interface EventOccurred extends AbstractEvent {
+    type: 'eventOccurred';
+    name: string;
+    testId?: string;
+    groupId?: string;
+    personalizationId: string;
+    audience?: string;
+    details: {[key: string]: string|number|boolean|null};
+}
+
 export type MiscEvent =
       NothingChanged
     | SessionAttributesChanged
     | TestGroupAssigned
-    | PersonalizationApplied
+    | EventOccurred
     | GoalCompleted;
 
 type EventMap = {
@@ -338,8 +340,8 @@ type EventMap = {
     nothingChanged: NothingChanged,
     sessionAttributesChanged: SessionAttributesChanged,
     testGroupAssigned: TestGroupAssigned,
-    personalizationApplied: PersonalizationApplied,
     goalCompleted: GoalCompleted,
+    eventOccurred: EventOccurred,
 }
 
 export type EventType = keyof EventMap;
@@ -368,8 +370,8 @@ type ExternalEventMap = {
     productViewed: ProductViewed,
     userSignedUp: UserSignedUp,
     testGroupAssigned: TestGroupAssigned,
-    personalizationApplied: PersonalizationApplied,
     goalCompleted: GoalCompleted,
+    eventOccurred: EventOccurred,
 };
 
 export type ExternalEventType = keyof ExternalEventMap;

--- a/src/facade/trackerFacade.ts
+++ b/src/facade/trackerFacade.ts
@@ -9,7 +9,7 @@ import {
     productViewed,
     userSignedUp,
     testGroupAssigned,
-    personalizationApplied,
+    eventOccurred,
     goalCompleted,
 } from '../schema/eventSchemas';
 
@@ -21,7 +21,7 @@ const eventSchemas = {
     productViewed,
     userSignedUp,
     testGroupAssigned,
-    personalizationApplied,
+    eventOccurred,
     goalCompleted,
 };
 

--- a/src/schema/eventSchemas.ts
+++ b/src/schema/eventSchemas.ts
@@ -3,6 +3,9 @@ import StringType from '../validation/stringType';
 import {cart, order, productDetails} from './ecommerceSchemas';
 import {userProfileSchema} from './userSchema';
 import NumberType from '../validation/numberType';
+import UnionType from '../validation/unionType';
+import NullType from '../validation/nullType';
+import BooleanType from '../validation/booleanType';
 
 export const cartModified = new ObjectType({
     required: ['cart'],
@@ -68,28 +71,6 @@ export const testGroupAssigned = new ObjectType({
     },
 });
 
-export const personalizationApplied = new ObjectType({
-    required: ['personalizationId'],
-    properties: {
-        personalizationId: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
-        audience: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
-        testId: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
-        groupId: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
-    },
-});
-
 export const goalCompleted = new ObjectType({
     required: ['goalId'],
     properties: {
@@ -103,6 +84,48 @@ export const goalCompleted = new ObjectType({
         currency: new StringType({
             minLength: 1,
             maxLength: 10,
+        }),
+    },
+});
+
+export const eventOccurred = new ObjectType({
+    required: ['name'],
+    properties: {
+        name: new StringType({
+            minLength: 1,
+            maxLength: 50,
+        }),
+        testId: new StringType({
+            minLength: 1,
+            maxLength: 50,
+        }),
+        groupId: new StringType({
+            minLength: 1,
+            maxLength: 50,
+        }),
+        personalizationId: new StringType({
+            minLength: 1,
+            maxLength: 50,
+        }),
+        audience: new StringType({
+            minLength: 1,
+            maxLength: 50,
+        }),
+        details: new ObjectType({
+            additionalProperties: new UnionType(
+                new NullType(),
+                new BooleanType(),
+                new NumberType(),
+                new StringType({
+                    maxLength: 300,
+                }),
+            ),
+            propertyNames: new StringType({
+                minLength: 1,
+                maxLength: 20,
+                format: 'identifier',
+            }),
+            maxProperties: 10,
         }),
     },
 });

--- a/test/facade/trackerFacade.test.ts
+++ b/test/facade/trackerFacade.test.ts
@@ -185,11 +185,15 @@ describe('A tracker facade', () => {
         ],
         [
             {
-                type: 'personalizationApplied',
+                type: 'eventOccurred',
+                name: 'event-name',
                 personalizationId: 'foo',
                 audience: 'bar',
                 testId: 'baz',
                 groupId: 'barbaz',
+                details: {
+                    foo: 'bar',
+                },
             },
         ],
         [

--- a/test/schemas/eventSchemas.test.ts
+++ b/test/schemas/eventSchemas.test.ts
@@ -7,7 +7,7 @@ import {
     productViewed,
     userSignedUp,
     testGroupAssigned,
-    personalizationApplied,
+    eventOccurred,
     goalCompleted,
 } from '../../src/schema/eventSchemas';
 import {Optional} from '../../src/utilityTypes';
@@ -257,20 +257,27 @@ describe('The "testGroupAssigned" payload schema', () => {
     });
 });
 
-describe('The "personalizationApplied" payload schema', () => {
+describe('The "eventOccurred" payload schema', () => {
     test.each([
         [{
-            personalizationId: 'foo',
+            name: 'foo',
         }],
         [{
+            name: 'event-name',
             personalizationId: 'foo',
             audience: 'bar',
             testId: 'baz',
             groupId: 'barbaz',
+            details: {
+                number: 10,
+                null: null,
+                string: 'string',
+                boolean: true,
+            },
         }],
     ])('should allow %s', (value: object) => {
         function validate(): void {
-            personalizationApplied.validate(value);
+            eventOccurred.validate(value);
         }
 
         expect(validate).not.toThrow(Error);
@@ -279,59 +286,114 @@ describe('The "personalizationApplied" payload schema', () => {
     test.each([
         [
             {},
-            'Missing property \'/personalizationId\'.',
+            'Missing property \'/name\'.',
         ],
         [
-            {personalizationId: ''},
+            {name: ''},
+            'Expected at least 1 character at path \'/name\', actual 0.',
+        ],
+        [
+            {name: 'x'.repeat(51)},
+            'Expected at most 50 characters at path \'/name\', actual 51.',
+        ],
+        [
+            {name: null},
+            'Expected value of type string at path \'/name\', actual null.',
+        ],
+        [
+            {name: 'foo', personalizationId: ''},
             'Expected at least 1 character at path \'/personalizationId\', actual 0.',
         ],
         [
-            {personalizationId: 'x'.repeat(51)},
+            {name: 'foo', personalizationId: 'x'.repeat(51)},
             'Expected at most 50 characters at path \'/personalizationId\', actual 51.',
         ],
         [
-            {personalizationId: null},
+            {name: 'foo', personalizationId: null},
             'Expected value of type string at path \'/personalizationId\', actual null.',
         ],
         [
-            {personalizationId: 'foo', audience: ''},
+            {name: 'foo', audience: ''},
             'Expected at least 1 character at path \'/audience\', actual 0.',
         ],
         [
-            {personalizationId: 'foo', audience: 'x'.repeat(51)},
+            {name: 'foo', audience: 'x'.repeat(51)},
             'Expected at most 50 characters at path \'/audience\', actual 51.',
         ],
         [
-            {personalizationId: 'foo', audience: null},
+            {name: 'foo', audience: null},
             'Expected value of type string at path \'/audience\', actual null.',
         ],
         [
-            {personalizationId: 'foo', testId: ''},
+            {name: 'foo', testId: ''},
             'Expected at least 1 character at path \'/testId\', actual 0.',
         ],
         [
-            {personalizationId: 'foo', testId: 'x'.repeat(51)},
+            {name: 'foo', testId: 'x'.repeat(51)},
             'Expected at most 50 characters at path \'/testId\', actual 51.',
         ],
         [
-            {personalizationId: 'foo', testId: null},
+            {name: 'foo', testId: null},
             'Expected value of type string at path \'/testId\', actual null.',
         ],
         [
-            {personalizationId: 'foo', groupId: ''},
+            {name: 'foo', groupId: ''},
             'Expected at least 1 character at path \'/groupId\', actual 0.',
         ],
         [
-            {personalizationId: 'foo', groupId: 'x'.repeat(51)},
+            {name: 'foo', groupId: 'x'.repeat(51)},
             'Expected at most 50 characters at path \'/groupId\', actual 51.',
         ],
         [
-            {personalizationId: 'foo', groupId: null},
+            {name: 'foo', groupId: null},
             'Expected value of type string at path \'/groupId\', actual null.',
+        ],
+        [
+            {name: 'foo', details: null},
+            'Expected value of type object at path \'/details\', actual null.',
+        ],
+        [
+            {name: 'foo', details: {'@bar': 1}},
+            'Invalid identifier format at path \'/details/@bar\'.',
+        ],
+        [
+            {name: 'foo', details: {looooooooooooooongKey: 'baz'}},
+            'Expected at most 20 characters at path \'/details/looooooooooooooongKey\', actual 21.',
+        ],
+        [
+            {name: 'foo', details: {longString: 'x'.repeat(301)}},
+            'Expected at most 300 characters at path \'/details/longString\', actual 301.',
+        ],
+        [
+            {name: 'foo', details: {bar: []}},
+            'Expected value of type null, boolean, number or string at path \'/details/bar\', actual array.',
+        ],
+        [
+            {name: 'foo', details: {bar: {}}},
+            'Expected value of type null, boolean, number or string at path \'/details/bar\', actual Object.',
+        ],
+        [
+            {
+                name: 'foo',
+                details: {
+                    a: 1,
+                    b: 2,
+                    c: 3,
+                    d: 4,
+                    e: 5,
+                    f: 6,
+                    g: 7,
+                    h: 8,
+                    i: 9,
+                    j: 10,
+                    k: 11,
+                },
+            },
+            'Expected at most 10 entries at path \'/details\', actual 11.',
         ],
     ])('should not allow %s', (value: object, message: string) => {
         function validate(): void {
-            personalizationApplied.validate(value);
+            eventOccurred.validate(value);
         }
 
         expect(validate).toThrow(Error);

--- a/test/tracker.test.ts
+++ b/test/tracker.test.ts
@@ -1133,11 +1133,15 @@ describe('A tracker', () => {
         ],
         [
             {
-                type: 'personalizationApplied',
+                type: 'eventOccurred',
+                name: 'event-name',
                 personalizationId: 'foo',
                 audience: 'bar',
                 testId: 'baz',
                 groupId: 'barbaz',
+                details: {
+                    foo: 'bar',
+                },
             },
             undefined,
         ],


### PR DESCRIPTION
## Summary
Deprecate event `personalizationApplied` in favor of `eventOccurred`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings