### PR TITLE
Use lexicographically sortable UUIDs for identifying tabs

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -22,7 +22,7 @@ export default class Context {
         let newTab = false;
 
         if (tabId === null) {
-            tabId = uuid4();
+            tabId = uuid4(true);
             newTab = true;
         }
 

--- a/src/uuid.ts
+++ b/src/uuid.ts
@@ -1,7 +1,12 @@
-export function uuid4(): string {
+export function uuid4(sortable = false): string {
     let uuid = '';
 
-    for (let index = 0; index < 36; index++) {
+    if (sortable) {
+        const prefix = Date.now().toString(16).padStart(12, '0').substring(0, 12);
+        uuid = `${prefix.substring(0, 8)}-${prefix.substring(8, 12)}`;
+    }
+
+    for (let index = uuid.length; index < 36; index++) {
         switch (index) {
             case 8:
             case 13:

--- a/test/uuid.test.ts
+++ b/test/uuid.test.ts
@@ -1,5 +1,9 @@
 import {uuid4} from '../src/uuid';
 
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
 describe('A UUID v4 function', () => {
     test('should generate a random UUID', () => {
         const generated = [];
@@ -12,5 +16,26 @@ describe('A UUID v4 function', () => {
 
             generated.push(uuid);
         }
+    });
+
+    test('should generate a random and lexicographically sortable UUID', async () => {
+        let timestamp: number = Date.now();
+        jest.spyOn(Date, 'now').mockImplementation(() => {
+            timestamp += 1;
+
+            return timestamp;
+        });
+
+        const generated = [];
+        for (let iteration = 0; iteration < 100; iteration++) {
+            const uuid = uuid4(true);
+
+            expect(uuid).toMatch(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
+            expect(generated).not.toContainEqual(uuid);
+
+            generated.push(uuid);
+        }
+
+        expect([...generated]).toEqual(generated.sort());
     });
 });


### PR DESCRIPTION
## Summary

Using a lexicographically sortable ID allows determining the order in which the tabs were opened without analyzing the sequence of events.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings