### PR TITLE
Allow passing a custom logger to SDK Facade

### DIFF
--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -19,6 +19,7 @@ export type Configuration = {
     token?: string,
     userId?: string,
     eventMetadata?: {[key: string]: string},
+    logger?: Logger,
     trackerEndpointUrl?: string,
     evaluationEndpointUrl?: string,
     bootstrapEndpointUrl?: string,

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -65,6 +65,8 @@ describe('A SDK facade', () => {
     test('should load the SDK using the specified configuration', () => {
         const initialize = jest.spyOn(Sdk, 'init');
 
+        const logger = new NullLogger();
+
         SdkFacade.init({
             appId: appId,
             track: false,
@@ -74,6 +76,7 @@ describe('A SDK facade', () => {
             debug: false,
             tokenScope: 'isolated',
             token: Token.issue(appId, 'c4r0l').toString(),
+            logger: logger,
         });
 
         expect(initialize).toBeCalledWith({
@@ -83,6 +86,7 @@ describe('A SDK facade', () => {
             bootstrapEndpointUrl: 'https://api.croct.io/bootstrap',
             debug: false,
             tokenScope: 'isolated',
+            logger: logger,
         });
     });
 


### PR DESCRIPTION
## Summary
Allow passing a custom logger to SDK Facade.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings