### PR TITLE
Add support for object subtype validation

### DIFF
--- a/test/validation/objectType.test.ts
+++ b/test/validation/objectType.test.ts
@@ -39,12 +39,47 @@ describe('An object type', () => {
             new ObjectType({additionalProperties: new NumberType({}), propertyNames: new StringType({minLength: 3})}),
         ],
         [
+            {foo: 4, bar: 5},
+            new ObjectType({additionalProperties: true}),
+        ],
+        [
             {foo: 6},
             new ObjectType({additionalProperties: new NumberType({}), minProperties: 1}),
         ],
         [
             {foo: 7},
             new ObjectType({additionalProperties: new NumberType({}), maxProperties: 1}),
+        ],
+        [
+            {type: 'foo', foo: 1},
+            new ObjectType({
+                properties: {
+                    type: new StringType({enumeration: ['foo', 'bar']}),
+                },
+                additionalProperties: true,
+                subtypes: {
+                    discriminator: 'type',
+                    schemas: {
+                        foo: new ObjectType({properties: {foo: new NumberType()}}),
+                        bar: new ObjectType({properties: {bar: new NumberType()}}),
+                    },
+                },
+            }),
+        ],
+        [
+            {type: 'foo'},
+            new ObjectType({
+                properties: {
+                    type: new StringType({enumeration: ['foo', 'bar']}),
+                },
+                additionalProperties: true,
+                subtypes: {
+                    discriminator: 'type',
+                    schemas: {
+                        foo: new ObjectType({properties: {bar: new NumberType()}}),
+                    },
+                },
+            }),
         ],
     ])('should allow %s with %o', (value: object, type: ObjectType) => {
         function validate(): void {
@@ -58,27 +93,27 @@ describe('An object type', () => {
         [
             null,
             new ObjectType({}),
-            'Expected value of type object at path \'/\', actual null.',
+            "Expected value of type object at path '/', actual null.",
         ],
         [
             'foo',
             new ObjectType({}),
-            'Expected value of type object at path \'/\', actual string.',
+            "Expected value of type object at path '/', actual string.",
         ],
         [
             1,
             new ObjectType({}),
-            'Expected value of type object at path \'/\', actual integer.',
+            "Expected value of type object at path '/', actual integer.",
         ],
         [
             true,
             new ObjectType({}),
-            'Expected value of type object at path \'/\', actual boolean.',
+            "Expected value of type object at path '/', actual boolean.",
         ],
         [
             {foo: 'bar'},
             new ObjectType({properties: {foo: new NumberType({})}}),
-            'Expected value of type number at path \'/foo\', actual string.',
+            "Expected value of type number at path '/foo', actual string.",
         ],
         [
             {bar: 1},
@@ -91,29 +126,107 @@ describe('An object type', () => {
             "Unknown property '/bar'.",
         ],
         [
+            {foo: '1', bar: 2},
+            new ObjectType({properties: {foo: new NumberType({})}, additionalProperties: true}),
+            "Expected value of type number at path '/foo', actual string.",
+        ],
+        [
             {bar: 'foo'},
             new ObjectType({additionalProperties: new NumberType({}), propertyNames: new StringType({minLength: 3})}),
-            'Expected value of type number at path \'/bar\', actual string.',
+            "Expected value of type number at path '/bar', actual string.",
         ],
         [
             {foobar: 1},
             new ObjectType({additionalProperties: new NumberType({}), propertyNames: new StringType({maxLength: 3})}),
-            'Expected at most 3 characters at path \'/foobar\', actual 6.',
+            "Expected at most 3 characters at path '/foobar', actual 6.",
         ],
         [
             {},
             new ObjectType({additionalProperties: new NumberType({}), minProperties: 1}),
-            'Expected at least 1 entry at path \'/\', actual 0.',
+            "Expected at least 1 entry at path '/', actual 0.",
         ],
         [
             {foo: 3, bar: 4},
             new ObjectType({additionalProperties: new NumberType({}), maxProperties: 1}),
-            'Expected at most 1 entry at path \'/\', actual 2.',
+            "Expected at most 1 entry at path '/', actual 2.",
         ],
         [
             {foo: 5, bar: 6},
             new ObjectType({additionalProperties: new NumberType({}), minProperties: 1, maxProperties: 1}),
-            'Expected exactly 1 entry at path \'/\', actual 2.',
+            "Expected exactly 1 entry at path '/', actual 2.",
+        ],
+        [
+            {type: 'foo', foo: '1'},
+            new ObjectType({
+                properties: {
+                    type: new StringType({enumeration: ['foo', 'bar']}),
+                },
+                additionalProperties: true,
+                subtypes: {
+                    discriminator: 'type',
+                    schemas: {
+                        foo: new ObjectType({properties: {foo: new NumberType()}}),
+                        bar: new ObjectType({properties: {bar: new NumberType()}}),
+                    },
+                },
+            }),
+            "Expected value of type number at path '/foo', actual string.",
+        ],
+        [
+            {type: 'bar', bar: '1'},
+            new ObjectType({
+                properties: {
+                    type: new StringType({enumeration: ['foo', 'bar']}),
+                },
+                additionalProperties: true,
+                subtypes: {
+                    discriminator: 'type',
+                    schemas: {
+                        foo: new ObjectType({properties: {foo: new NumberType()}}),
+                        bar: new ObjectType({properties: {bar: new NumberType()}}),
+                    },
+                },
+            }),
+            "Expected value of type number at path '/bar', actual string.",
+        ],
+        [
+            {type: 'foo'},
+            new ObjectType({
+                properties: {
+                    type: new StringType({enumeration: ['foo', 'bar']}),
+                },
+                additionalProperties: true,
+                subtypes: {
+                    discriminator: 'type',
+                    schemas: {
+                        foo: new ObjectType({
+                            required: ['foo'],
+                            properties: {foo: new NumberType()},
+                        }),
+                        bar: new ObjectType({
+                            required: ['bar'],
+                            properties: {bar: new NumberType()},
+                        }),
+                    },
+                },
+            }),
+            "Missing property '/foo'.",
+        ],
+        [
+            {type: 'foo', foo: 1},
+            new ObjectType({
+                properties: {
+                    type: new StringType({enumeration: ['foo', 'bar']}),
+                },
+                additionalProperties: false,
+                subtypes: {
+                    discriminator: 'type',
+                    schemas: {
+                        foo: new ObjectType({properties: {foo: new NumberType()}}),
+                    },
+                },
+            }),
+            "Unknown property '/foo'.",
         ],
     ])('should not allow %s with %o', (
         value: any,


### PR DESCRIPTION
## Summary
Add support for object subtype validation.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings