### PR TITLE
Change max length for custom key from 20 to 50 characters

### DIFF
--- a/src/schema/userSchema.ts
+++ b/src/schema/userSchema.ts
@@ -84,7 +84,7 @@ export const userProfileSchema = new ObjectType({
         }),
         custom: new ObjectType({
             propertyNames: new StringType({
-                maxLength: 20,
+                maxLength: 50,
                 format: 'identifier',
             }),
             maxProperties: 10,
@@ -108,7 +108,7 @@ export const userProfileSchema = new ObjectType({
                 }),
                 new ObjectType({
                     propertyNames: new StringType({
-                        maxLength: 20,
+                        maxLength: 50,
                         format: 'identifier',
                     }),
                     maxProperties: 10,

--- a/test/schemas/userSchema.test.ts
+++ b/test/schemas/userSchema.test.ts
@@ -166,12 +166,14 @@ describe('The user profile schema', () => {
             'Expected at most 100 characters at path \'/custom/longString\', actual 101.',
         ],
         [
-            {custom: {looooooooooooooongKey: 'x'}},
-            'Expected at most 20 characters at path \'/custom/looooooooooooooongKey\', actual 21.',
+            {custom: {looooooooooooooooooooooooooooooooooooooooooooongKey: 'x'}},
+            'Expected at most 50 characters at path '
+                + '\'/custom/looooooooooooooooooooooooooooooooooooooooooooongKey\', actual 51.',
         ],
         [
-            {custom: {map: {looooooooooooooongKey: 'x'}}},
-            'Expected at most 20 characters at path \'/custom/map/looooooooooooooongKey\', actual 21.',
+            {custom: {map: {looooooooooooooooooooooooooooooooooooooooooooongKey: 'x'}}},
+            'Expected at most 50 characters at path '
+                + '\'/custom/map/looooooooooooooooooooooooooooooooooooooooooooongKey\', actual 51.',
         ],
         [
             {custom: {'@foo': 1}},


### PR DESCRIPTION
## Summary

Change max length for custom key from 20 to 50 characters.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings