### PR TITLE
Allow unset any existing token on initialization

### DIFF
--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -18,7 +18,7 @@ export type Configuration = {
     tokenScope?: TokenScope,
     debug?: boolean,
     track?: boolean,
-    token?: string,
+    token?: string | null,
     userId?: string,
     eventMetadata?: {[key: string]: string},
     logger?: Logger,
@@ -74,7 +74,11 @@ export default class SdkFacade {
         if (userId !== undefined) {
             sdk.identify(userId);
         } else if (token !== undefined) {
-            sdk.setToken(Token.parse(token));
+            if (token === null) {
+                sdk.unsetToken();
+            } else {
+                sdk.setToken(Token.parse(token));
+            }
         }
 
         if (track) {

--- a/src/schema/sdkFacadeSchemas.ts
+++ b/src/schema/sdkFacadeSchemas.ts
@@ -4,6 +4,8 @@ import BooleanType from '../validation/booleanType';
 import {tokenScopeSchema} from './contextSchemas';
 import {eventMetadataSchema} from './sdkSchemas';
 import {loggerSchema} from './loggerSchema';
+import UnionType from '../validation/unionType';
+import NullType from '../validation/nullType';
 
 export const configurationSchema = new ObjectType({
     required: ['appId'],
@@ -22,9 +24,12 @@ export const configurationSchema = new ObjectType({
         userId: new StringType({
             minLength: 1,
         }),
-        token: new StringType({
-            pattern: /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$/,
-        }),
+        token: new UnionType(
+            new StringType({
+                pattern: /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$/,
+            }),
+            new NullType(),
+        ),
         trackerEndpointUrl: new StringType({
             format: 'url',
         }),

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -133,6 +133,29 @@ describe('A SDK facade', () => {
         expect(context.setToken).toBeCalledTimes(1);
     });
 
+    test('should load the SDK and unset any existing token', () => {
+        const context = createContextMock();
+
+        context.getToken = jest.fn().mockImplementation(() => Token.issue(appId, 'c4r0l'));
+
+        jest.spyOn(Sdk, 'init')
+            .mockImplementationOnce(config => {
+                const sdk = Sdk.init(config);
+
+                jest.spyOn(sdk, 'context', 'get').mockReturnValue(context);
+
+                return sdk;
+            });
+
+        SdkFacade.init({
+            appId: appId,
+            token: null,
+            track: false,
+        });
+
+        expect(context.setToken).toBeCalledWith(null);
+    });
+
     test('should load the SDK and set a token for the provided user ID', () => {
         const context = createContextMock();
 

--- a/test/schemas/sdkFacadeSchemas.test.ts
+++ b/test/schemas/sdkFacadeSchemas.test.ts
@@ -15,6 +15,10 @@ describe('The SDK facade configuration schema', () => {
         }],
         [{
             appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+            token: null,
+        }],
+        [{
+            appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
             trackerEndpointUrl: 'https://api.croct.io/tracker',
             evaluationEndpointUrl: 'https://api.croct.io/evaluation',
             bootstrapEndpointUrl: 'https://api.croct.io/bootstrap',
@@ -77,7 +81,7 @@ describe('The SDK facade configuration schema', () => {
         ],
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', token: 1},
-            "Expected value of type string at path '/token', actual integer.",
+            "Expected value of type string or null at path '/token', actual integer.",
         ],
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', debug: 'foo'},


### PR DESCRIPTION
## Summary
The need for this feature arose during the development of the playground plugin. When initializing the SDK, there is currently no easy way to either specify a token or unset any existing.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings