### PR TITLE
Replace configurable max expression length with a hardcoded limit

### DIFF
--- a/.github/workflows/deploy-published-releases.yaml
+++ b/.github/workflows/deploy-published-releases.yaml
@@ -44,7 +44,7 @@ jobs:
           sed -i -e "s~<@trackerEndpointUrl@>~${TRACKER_ENDPOINT}~" constants.js
           sed -i -e "s~<@evaluationEndpointUrl@>~${EVALUATION_ENDPOINT}~" constants.js
           sed -i -e "s~<@bootstrapEndpointUrl@>~${BOOTSTRAP_ENDPOINT}~" constants.js
-          sed -i -e "s~<@maxExpressionLength@>~${MAX_EXPRESSION_LENGHT}~" constants.js
+          sed -i -e "s~parseInt('<@maxExpressionLength@>', 10)~${MAX_EXPRESSION_LENGHT}~" constants.js
 
       - name: Publish pre-release to NPM
         if: ${{ github.event.release.prerelease }}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const TRACKER_ENDPOINT_URL = '<@trackerEndpointUrl@>';
 export const EVALUATION_ENDPOINT_URL = '<@evaluationEndpointUrl@>';
 export const BOOTSTRAP_ENDPOINT_URL = '<@bootstrapEndpointUrl@>';
-export const MAX_EXPRESSION_LENGTH = window.parseInt('<@maxExpressionLength@>', 10);
+export const MAX_EXPRESSION_LENGTH = parseInt('<@maxExpressionLength@>', 10);
 export const VERSION = '<@version@>';


### PR DESCRIPTION
## Summary
The limit is currently defined in compile time by replacing a token string with the actual value. To avoid runtime errors, the limit is specified as a string and converted in runtime to a number. This causes an error when pre-rendering SSR applications like Next.js because `window` does not exist.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings