### PR TITLE
Make userId accept null values in SDK Configuration

### DIFF
--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -20,7 +20,7 @@ export type Configuration = {
     debug?: boolean,
     track?: boolean,
     token?: string | null,
-    userId?: string,
+    userId?: string | null,
     eventMetadata?: {[key: string]: string},
     logger?: Logger,
     urlSanitizer?: UrlSanitizer,
@@ -74,7 +74,11 @@ export default class SdkFacade {
         );
 
         if (userId !== undefined) {
-            sdk.identify(userId);
+            if (userId === null) {
+                sdk.anonymize();
+            } else {
+                sdk.identify(userId);
+            }
         } else if (token !== undefined) {
             if (token === null) {
                 sdk.unsetToken();

--- a/src/schema/sdkFacadeSchemas.ts
+++ b/src/schema/sdkFacadeSchemas.ts
@@ -23,9 +23,12 @@ export const configurationSchema = new ObjectType({
         logger: loggerSchema,
         urlSanitizer: new FunctionType(),
         eventMetadata: eventMetadataSchema,
-        userId: new StringType({
-            minLength: 1,
-        }),
+        userId: new UnionType(
+            new StringType({
+                minLength: 1,
+            }),
+            new NullType(),
+        ),
         token: new UnionType(
             new StringType({
                 pattern: /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$/,

--- a/test/schemas/sdkFacadeSchemas.test.ts
+++ b/test/schemas/sdkFacadeSchemas.test.ts
@@ -19,6 +19,14 @@ describe('The SDK facade configuration schema', () => {
         }],
         [{
             appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+            userId: 'foo',
+        }],
+        [{
+            appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+            userId: null,
+        }],
+        [{
+            appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
             trackerEndpointUrl: 'https://api.croct.io/tracker',
             evaluationEndpointUrl: 'https://api.croct.io/evaluation',
             bootstrapEndpointUrl: 'https://api.croct.io/bootstrap',
@@ -73,7 +81,7 @@ describe('The SDK facade configuration schema', () => {
         ],
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', userId: 1},
-            "Expected value of type string at path '/userId', actual integer.",
+            "Expected value of type string or null at path '/userId', actual integer.",
         ],
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', token: 'foo'},


### PR DESCRIPTION
## Summary

The SDK currently accepts a null user ID, but the plug validation doesn't.

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings