### PR TITLE
Fix JWT token parsing to accept aud as array

### DIFF
--- a/src/schema/tokenSchema.ts
+++ b/src/schema/tokenSchema.ts
@@ -1,4 +1,4 @@
-import {ObjectType, StringType, NumberType} from '../validation';
+import {ObjectType, StringType, NumberType, UnionType, ArrayType} from '../validation';
 
 export const tokenSchema = new ObjectType({
     required: ['headers', 'claims'],
@@ -18,7 +18,10 @@ export const tokenSchema = new ObjectType({
             required: ['iss', 'aud', 'iat'],
             properties: {
                 iss: new StringType(),
-                aud: new StringType(),
+                aud: new UnionType(
+                    new StringType(),
+                    new ArrayType({items: new StringType()}),
+                ),
                 iat: new NumberType({
                     minimum: 0,
                 }),

--- a/src/token/token.ts
+++ b/src/token/token.ts
@@ -11,7 +11,7 @@ export type Headers = {
 
 export type Claims = {
     iss: string,
-    aud: string,
+    aud: string|string[],
     iat: number,
     exp?: number,
     sub?: string,

--- a/test/schemas/tokenSchema.test.ts
+++ b/test/schemas/tokenSchema.test.ts
@@ -31,6 +31,18 @@ describe('The token schema', () => {
                 iat: 1440982923,
             },
         }],
+        [{
+            headers: {
+                typ: 'JWT',
+                alg: 'none',
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+            },
+            claims: {
+                iss: 'croct.io',
+                aud: ['croct.io'],
+                iat: 1440982923,
+            },
+        }],
     ])('should allow %s', (value: Record<string, unknown>) => {
         function validate(): void {
             tokenSchema.validate(value);
@@ -184,7 +196,7 @@ describe('The token schema', () => {
                     iat: 1440982923,
                 },
             },
-            'Expected value of type string at path \'/claims/aud\', actual integer.',
+            'Expected value of type string or array at path \'/claims/aud\', actual integer.',
         ],
         [
             {

--- a/test/token/token.test.ts
+++ b/test/token/token.test.ts
@@ -93,6 +93,27 @@ describe('A token', () => {
         expect(anonymousToken.toString()).toBe(encodedToken);
     });
 
+    test('should parse a token with a list of audiences', () => {
+        const token = Token.parse(
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIiwiYXBwSWQiOiI3ZTlkNTlhOS1lNGIzLTQ1ZDQtYjFjNy00OD'
+            + 'I4N2YxZTVlOGEifQ.eyJpc3MiOiJjcm9jdC5pbyIsImF1ZCI6WyJjcm9jdC5pbyJdLCJpYXQiOjE0NDA5'
+            + 'ODI5MjMsInN1YiI6ImM0cjBsIn0.',
+        );
+
+        expect(token.getHeaders()).toEqual({
+            typ: 'JWT',
+            alg: 'none',
+            appId: appId,
+        });
+
+        expect(token.getClaims()).toEqual({
+            sub: 'c4r0l',
+            iss: 'croct.io',
+            aud: ['croct.io'],
+            iat: 1440982923,
+        });
+    });
+
     test('should fail to parse an empty token', () => {
         function invalidToken(): void {
             Token.parse('');


### PR DESCRIPTION
## Summary
Fix JWT token parsing to accept `aud` as an array.

> In the general case, the `aud` value is an array of case-sensitive strings, each containing a `StringOrURI`.  In the special case when the JWT has one audience, the `aud` value MAY be a single case-sensitive string containing a `StringOrURI` value.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings