### PR TITLE
Use object instead of Headers

### DIFF
--- a/src/contentFetcher.ts
+++ b/src/contentFetcher.ts
@@ -159,35 +159,37 @@ export class ContentFetcher {
 
         const {apiKey, appId} = this.configuration;
 
-        const headers = new Headers();
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        };
 
-        headers.set('X-Client-Library', CLIENT_LIBRARY);
+        headers['X-Client-Library'] = CLIENT_LIBRARY;
 
         if (appId !== undefined) {
-            headers.set('X-App-Id', appId);
+            headers['X-App-Id'] = appId;
         }
 
         if (apiKey !== undefined) {
-            headers.set('X-Api-Key', apiKey);
+            headers['X-Api-Key'] = apiKey;
         }
 
         const dynamic = ContentFetcher.isDynamicContent(options);
 
         if (dynamic) {
             if (options.clientId !== undefined) {
-                headers.set('X-Client-Id', options.clientId);
+                headers['X-Client-Id'] = options.clientId;
             }
 
             if (options.clientIp !== undefined) {
-                headers.set('X-Client-Ip', options.clientIp);
+                headers['X-Client-Ip'] = options.clientIp;
             }
 
             if (options.userToken !== undefined) {
-                headers.set('X-Token', options.userToken.toString());
+                headers['X-Token'] = options.userToken.toString();
             }
 
             if (options.userAgent !== undefined) {
-                headers.set('User-Agent', options.userAgent);
+                headers['User-Agent'] = options.userAgent;
             }
 
             if (options.version !== undefined) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -210,30 +210,32 @@ export class Evaluator {
         const {appId, apiKey} = this.configuration;
         const {clientId, clientIp, userAgent, userToken} = options;
 
-        const headers = new Headers();
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        };
 
-        headers.set('X-Client-Library', CLIENT_LIBRARY);
+        headers['X-Client-Library'] = CLIENT_LIBRARY;
 
         if (apiKey !== undefined) {
-            headers.set('X-Api-Key', apiKey);
+            headers['X-Api-Key'] = apiKey;
         } else if (appId !== undefined) {
-            headers.set('X-App-Id', appId);
+            headers['X-App-Id'] = appId;
         }
 
         if (clientId !== undefined) {
-            headers.set('X-Client-Id', clientId);
+            headers['X-Client-Id'] = clientId;
         }
 
         if (clientIp !== undefined) {
-            headers.set('X-Client-Ip', clientIp);
+            headers['X-Client-Ip'] = clientIp;
         }
 
         if (userToken !== undefined) {
-            headers.set('X-Token', userToken.toString());
+            headers['X-Token'] = userToken.toString();
         }
 
         if (userAgent !== undefined) {
-            headers.set('User-Agent', userAgent);
+            headers['User-Agent'] = userAgent;
         }
 
         return fetch(this.endpoint, {

--- a/test/contentFetcher.test.ts
+++ b/test/contentFetcher.test.ts
@@ -28,6 +28,7 @@ describe('A content fetcher', () => {
     const requestMatcher: MockOptions = {
         method: 'POST',
         headers: {
+            'Content-Type': 'application/json',
             'X-Client-Library': CLIENT_LIBRARY,
         },
         body: {

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -30,6 +30,7 @@ describe('An evaluator', () => {
     const requestMatcher: MockOptions = {
         method: 'POST',
         headers: {
+            'Content-Type': 'application/json',
             'X-Client-Library': CLIENT_LIBRARY,
         },
         body: {


### PR DESCRIPTION
## Summary
Node does not support `Header`, so revert to use plain object instead.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings