### PR TITLE
Fix fetch options and improve error reporting

### DIFF
--- a/src/contentFetcher.ts
+++ b/src/contentFetcher.ts
@@ -135,6 +135,13 @@ export class ContentFetcher {
                             } else {
                                 reject(new ContentError(body));
                             }
+                        })
+                        .catch(error => {
+                            if (!response.ok) {
+                                throw new Error(`Error ${response.status} - ${response.statusText}`);
+                            }
+
+                            throw error;
                         }),
                 )
                 .catch(error => {
@@ -153,10 +160,6 @@ export class ContentFetcher {
     }
 
     private load(slotId: string, signal: AbortSignal, options: FetchOptions): Promise<Response> {
-        const payload: FetchPayload = {
-            slotId: slotId,
-        };
-
         const {apiKey, appId} = this.configuration;
 
         const headers: Record<string, string> = {
@@ -171,6 +174,18 @@ export class ContentFetcher {
 
         if (apiKey !== undefined) {
             headers['X-Api-Key'] = apiKey;
+        }
+
+        const payload: FetchPayload = {
+            slotId: slotId,
+        };
+
+        if (options.version !== undefined) {
+            payload.version = `${options.version}`;
+        }
+
+        if (options.preferredLocale !== undefined) {
+            payload.preferredLocale = options.preferredLocale;
         }
 
         const dynamic = ContentFetcher.isDynamicContent(options);
@@ -190,14 +205,6 @@ export class ContentFetcher {
 
             if (options.userAgent !== undefined) {
                 headers['User-Agent'] = options.userAgent;
-            }
-
-            if (options.version !== undefined) {
-                payload.version = `${options.version}`;
-            }
-
-            if (options.preferredLocale !== undefined) {
-                payload.preferredLocale = options.preferredLocale;
             }
 
             if (options.context !== undefined) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -187,6 +187,13 @@ export class Evaluator {
 
                                 break;
                         }
+                    })
+                    .catch(error => {
+                        if (!response.ok) {
+                            throw new Error(`Error ${response.status} - ${response.statusText}`);
+                        }
+
+                        throw error;
                     }),
             )
                 .catch(

--- a/test/contentFetcher.test.ts
+++ b/test/contentFetcher.test.ts
@@ -90,7 +90,7 @@ describe('A content fetcher', () => {
         await expect(fetcher.fetch(contentId, options)).resolves.toEqual(content);
     });
 
-    it('should requite an API key to fetch static content', async () => {
+    it('should require an API key to fetch static content', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,
         });
@@ -117,7 +117,61 @@ describe('A content fetcher', () => {
         await expect(fetcher.fetch(contentId)).resolves.toEqual(content);
     });
 
-    it('should fetch content using the provided client ID', async () => {
+    it('should fetch static content for the specified slot version', async () => {
+        const fetcher = new ContentFetcher({
+            apiKey: apiKey,
+        });
+
+        const options: FetchOptions = {
+            static: true,
+            version: 2,
+        };
+
+        fetchMock.mock({
+            ...requestMatcher,
+            matcher: `${BASE_ENDPOINT_URL}/external/web/static-content`,
+            headers: {
+                ...requestMatcher.headers,
+                'X-Api-Key': apiKey,
+            },
+            body: {
+                ...requestMatcher.body,
+                version: `${options.version}`,
+            },
+            response: content,
+        });
+
+        await expect(fetcher.fetch(contentId, options)).resolves.toEqual(content);
+    });
+
+    it('should fetch static content for the specified preferred locale', async () => {
+        const fetcher = new ContentFetcher({
+            apiKey: apiKey,
+        });
+
+        const options: FetchOptions = {
+            static: true,
+            preferredLocale: 'en-US',
+        };
+
+        fetchMock.mock({
+            ...requestMatcher,
+            matcher: `${BASE_ENDPOINT_URL}/external/web/static-content`,
+            headers: {
+                ...requestMatcher.headers,
+                'X-Api-Key': apiKey,
+            },
+            body: {
+                ...requestMatcher.body,
+                preferredLocale: options.preferredLocale,
+            },
+            response: content,
+        });
+
+        await expect(fetcher.fetch(contentId, options)).resolves.toEqual(content);
+    });
+
+    it('should fetch dynamic content using the provided client ID', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,
         });
@@ -140,7 +194,7 @@ describe('A content fetcher', () => {
         await expect(fetcher.fetch(contentId, options)).resolves.toEqual(content);
     });
 
-    it('should fetch content passing the provided client IP', async () => {
+    it('should fetch dynamic content passing the provided client IP', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,
         });
@@ -163,7 +217,7 @@ describe('A content fetcher', () => {
         await expect(fetcher.fetch(contentId, options)).resolves.toEqual(content);
     });
 
-    it('should fetch content passing the provided user agent', async () => {
+    it('should fetch dynamic content passing the provided user agent', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,
         });
@@ -186,7 +240,7 @@ describe('A content fetcher', () => {
         await expect(fetcher.fetch(contentId, options)).resolves.toEqual(content);
     });
 
-    it('should fetch content using the provided user token', async () => {
+    it('should fetch dynamic content using the provided user token', async () => {
         const token = Token.issue(appId, 'foo', Date.now());
 
         const fetcher = new ContentFetcher({
@@ -209,7 +263,7 @@ describe('A content fetcher', () => {
         await expect(fetcher.fetch(contentId, options)).resolves.toEqual(content);
     });
 
-    it('should fetch content using the provided preview token', async () => {
+    it('should fetch dynamic content using the provided preview token', async () => {
         const token = Token.issue(appId, 'foo', Date.now());
 
         const fetcher = new ContentFetcher({
@@ -303,7 +357,7 @@ describe('A content fetcher', () => {
         expect(fetchOptions?.signal.aborted).toBe(true);
     });
 
-    it('should fetch content using the provided context', async () => {
+    it('should fetch dynamic content using the provided context', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,
         });
@@ -341,7 +395,7 @@ describe('A content fetcher', () => {
         await expect(promise).resolves.toEqual(content);
     });
 
-    it('should fetch content for the specified slot version', async () => {
+    it('should fetch dynamic content for the specified slot version', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,
         });
@@ -362,7 +416,7 @@ describe('A content fetcher', () => {
         await expect(promise).resolves.toEqual(content);
     });
 
-    it('should fetch content for the specified preferred locale', async () => {
+    it('should fetch dynamic content for the specified preferred locale', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,
         });
@@ -414,7 +468,7 @@ describe('A content fetcher', () => {
         });
 
         const response: ErrorResponse = {
-            title: expect.stringMatching('Invalid json response body'),
+            title: 'Error 500 - Internal Server Error',
             type: ContentErrorType.UNEXPECTED_ERROR,
             detail: 'Please try again or contact Croct support if the error persists.',
             status: 500,
@@ -423,7 +477,8 @@ describe('A content fetcher', () => {
         fetchMock.mock({
             ...requestMatcher,
             response: {
-                body: 'non-json',
+                status: 500,
+                body: 'Invalid JSON payload',
             },
         });
 

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -430,7 +430,7 @@ describe('An evaluator', () => {
         });
 
         const response: ErrorResponse = {
-            title: expect.stringMatching('Invalid json response body'),
+            title: 'Error 500 - Internal Server Error',
             type: EvaluationErrorType.UNEXPECTED_ERROR,
             detail: 'Please try again or contact Croct support if the error persists.',
             status: 500,
@@ -439,7 +439,8 @@ describe('An evaluator', () => {
         fetchMock.mock({
             ...requestMatcher,
             response: {
-                body: 'non-json',
+                status: 500,
+                body: 'Invalid JSON payload',
             },
         });
 


### PR DESCRIPTION
## Summary
Fix options not ignored for static content fetching and improve error reporting when the response does not include a valid JSON payload.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings