### PR TITLE
Remove campaign from evaluation context

### DIFF
--- a/.github/workflows/branch-validations.yaml
+++ b/.github/workflows/branch-validations.yaml
@@ -32,7 +32,7 @@ jobs:
         run: npm ci
 
       - name: Check dependency vulnerabilities
-        run: npm audit
+        run: npm audit --only=prod
 
   validate:
     runs-on: ubuntu-latest

--- a/src/facade/evaluatorFacade.ts
+++ b/src/facade/evaluatorFacade.ts
@@ -1,5 +1,5 @@
 import {JsonObject, JsonValue} from '@croct/json';
-import {Evaluator, Campaign, EvaluationContext, Page} from '../evaluator';
+import {Evaluator, EvaluationContext, Page} from '../evaluator';
 import {Tab} from '../tab';
 import {evaluationOptionsSchema as optionsSchema} from '../schema';
 import {formatCause} from '../error';
@@ -102,51 +102,10 @@ export class TabContextFactory implements ContextFactory {
             context.timeZone = timeZone;
         }
 
-        const campaign = TabContextFactory.createCampaign(url);
-
-        if (Object.keys(campaign).length > 0) {
-            context.campaign = campaign;
-        }
-
         if (attributes !== undefined && Object.keys(attributes).length > 0) {
             context.attributes = attributes;
         }
 
         return context;
-    }
-
-    private static createCampaign(url: URL): Campaign {
-        const campaign: Campaign = {};
-
-        for (const [parameter, value] of url.searchParams.entries()) {
-            switch (parameter.toLowerCase()) {
-                case 'utm_campaign':
-                    campaign.name = value;
-
-                    break;
-
-                case 'utm_source':
-                    campaign.source = value;
-
-                    break;
-
-                case 'utm_term':
-                    campaign.term = value;
-
-                    break;
-
-                case 'utm_medium':
-                    campaign.medium = value;
-
-                    break;
-
-                case 'utm_content':
-                    campaign.content = value;
-
-                    break;
-            }
-        }
-
-        return campaign;
     }
 }

--- a/test/facade/contentFecherFacade.test.ts
+++ b/test/facade/contentFecherFacade.test.ts
@@ -120,13 +120,6 @@ describe('A content fetcher facade', () => {
                     referrer: referrer,
                 },
                 timeZone: timeZone,
-                campaign: {
-                    name: 'campaign',
-                    source: 'source',
-                    medium: 'medium',
-                    content: 'content',
-                    term: 'term',
-                },
             },
         };
 

--- a/test/facade/evaluatorFacade.test.ts
+++ b/test/facade/evaluatorFacade.test.ts
@@ -1,6 +1,6 @@
 import {JsonObject} from '@croct/json';
 import {EvaluatorFacade, MinimalContextFactory, TabContextFactory} from '../../src/facade';
-import {Evaluator, Campaign, EvaluationOptions, Page} from '../../src/evaluator';
+import {Evaluator, EvaluationOptions, Page} from '../../src/evaluator';
 import {Tab} from '../../src/tab';
 import {FixedAssigner} from '../../src/cid';
 import {InMemoryTokenStore, FixedTokenProvider, Token} from '../../src/token';
@@ -114,13 +114,6 @@ describe('An evaluator facade', () => {
                     referrer: referrer,
                 },
                 timeZone: timeZone,
-                campaign: {
-                    name: 'campaign',
-                    source: 'source',
-                    medium: 'medium',
-                    content: 'content',
-                    term: 'term',
-                },
             },
             timeout: 5,
         };
@@ -163,13 +156,6 @@ describe('A tab context factory', () => {
 
     it('should load a context containing tab information and attributes', () => {
         const url = new URL('http://localhost');
-
-        url.searchParams.append('UTM_campaign', 'campaign');
-        url.searchParams.append('utm_SOURCE', 'source');
-        url.searchParams.append('utm_mediuM', 'medium');
-        url.searchParams.append('utm_Content', 'content');
-        url.searchParams.append('UTM_TERM', 'term');
-
         const title = 'Welcome to Foo Inc.';
         const referrer = 'http://referrer.com?foo=%22bar%22&foo="bar"';
 
@@ -195,16 +181,9 @@ describe('A tab context factory', () => {
             url: window.encodeURI(window.decodeURI(url.toString())),
             referrer: window.encodeURI(window.decodeURI(referrer)),
         };
-        const campaign: Campaign = {
-            name: 'campaign',
-            source: 'source',
-            medium: 'medium',
-            content: 'content',
-            term: 'term',
-        };
 
         expect(context.attributes).toEqual(attributes);
-        expect(context.campaign).toEqual(campaign);
+        expect(context.campaign).toBeUndefined();
         expect(context.page).toEqual(page);
         expect(context.timeZone).toBe(timeZone);
     });


### PR DESCRIPTION
## Summary
The evaluation service can now extract campaign information from the page URI for improved consistency across client-side and server-side rendering.

This PR removes the campaign extraction logic to ensure consistency across libraries.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings