### PR TITLE
Disable token refresh

### DIFF
--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -75,7 +75,11 @@ export class SdkFacade {
         );
 
         if (userId !== undefined) {
-            sdk.identify(userId);
+            const currentToken = sdk.context.getToken();
+
+            if (currentToken?.getSubject() !== userId) {
+                sdk.identify(userId);
+            }
         } else if (token !== undefined) {
             if (token === null) {
                 sdk.unsetToken();

--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -22,7 +22,7 @@ export type Configuration = {
     test?: boolean,
     track?: boolean,
     token?: string | null,
-    userId?: string,
+    userId?: string | null,
     clientId?: string,
     eventMetadata?: {[key: string]: string},
     logger?: Logger,
@@ -75,10 +75,14 @@ export class SdkFacade {
         );
 
         if (userId !== undefined) {
-            const currentToken = sdk.context.getToken();
+            if (userId === null) {
+                sdk.unsetToken();
+            } else {
+                const currentToken = sdk.context.getToken();
 
-            if (currentToken?.getSubject() !== userId) {
-                sdk.identify(userId);
+                if (currentToken?.getSubject() !== userId) {
+                    sdk.identify(userId);
+                }
             }
         } else if (token !== undefined) {
             if (token === null) {

--- a/src/schema/sdkFacadeSchemas.ts
+++ b/src/schema/sdkFacadeSchemas.ts
@@ -19,9 +19,12 @@ export const sdkFacadeConfigurationSchema = new ObjectType({
         logger: loggerSchema,
         urlSanitizer: new FunctionType(),
         eventMetadata: eventMetadataSchema,
-        userId: new StringType({
-            minLength: 1,
-        }),
+        userId: new UnionType(
+            new StringType({
+                minLength: 1,
+            }),
+            new NullType(),
+        ),
         token: new UnionType(
             new StringType({
                 pattern: /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$/,

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -49,7 +49,6 @@ describe('A SDK facade', () => {
 
     afterEach(() => {
         jest.restoreAllMocks();
-        jest.useRealTimers();
     });
 
     it('should fail if the configuration is not a key-value map', () => {

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -465,6 +465,35 @@ describe('A SDK facade', () => {
         expect(context.setToken).not.toHaveBeenCalled();
     });
 
+    it('should allow unidentifying a user', () => {
+        const context = createContextMock();
+
+        jest.spyOn(context, 'getToken')
+            .mockImplementation(() => Token.issue(appId, 'c4r0l'));
+
+        jest.spyOn(context, 'setToken')
+            .mockImplementation();
+
+        jest.spyOn(Sdk, 'init')
+            .mockImplementationOnce(config => {
+                const sdk = Sdk.init(config);
+
+                jest.spyOn(sdk, 'appId', 'get').mockReturnValue(appId);
+                jest.spyOn(sdk, 'context', 'get').mockReturnValue(context);
+
+                return sdk;
+            });
+
+        SdkFacade.init({
+            appId: appId,
+            track: false,
+            userId: null,
+        });
+
+        expect(context.setToken).toHaveBeenCalledWith(null);
+        expect(context.setToken).toHaveBeenCalledTimes(1);
+    });
+
     it('should allow anonymizing a user', () => {
         const context = createContextMock();
 

--- a/test/schemas/sdkFacadeSchemas.test.ts
+++ b/test/schemas/sdkFacadeSchemas.test.ts
@@ -19,6 +19,10 @@ describe('The SDK facade configuration schema', () => {
         }],
         [{
             appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+            userId: null,
+        }],
+        [{
+            appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
             baseEndpointUrl: 'https://api.croct.io/',
             cidAssignerEndpointUrl: 'https://api.croct.io/cid',
             tokenScope: 'isolated',
@@ -69,7 +73,7 @@ describe('The SDK facade configuration schema', () => {
         ],
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', userId: 1},
-            "Expected value of type string at path '/userId', actual integer.",
+            "Expected value of type string or null at path '/userId', actual integer.",
         ],
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', token: 'foo'},


### PR DESCRIPTION
## Summary
Prior to this PR, a new plain token was issued each time the SDK was initialized with a user ID. Whenever the user reloads the page (navigating between pages or via refresh), the SDK tracks a change in page visibility. Because the token is regenerated on each initialization, on the next page, the SDK tries to send the last pending event (`pageVisibilityChanged`) using the previous token. Then, a new connection is opened on the first event sent with the new token.

This PR changes the logic so tokens are not automatically updated when the SDK is initialized, and the same user ID is passed. In this case, if the subject of the token remains the same, it will keep the current token.

Now, passing a `userId: null` is possible to remove any existing token – the same behavior that is already supported for the `token`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings