### PR TITLE
Add support for cookie migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@croct/json": "^2.0.1",
-        "tslib": "^2.4.1"
+        "tslib": "^2.5.0"
       },
       "devDependencies": {
-        "@croct/eslint-plugin": "^0.6.3",
+        "@croct/eslint-plugin": "^0.6.6",
         "@types/jest": "^29.2.3",
         "eslint": "^8.27.0",
         "fetch-mock": "^9.11.0",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   },
   "dependencies": {
     "@croct/json": "^2.0.1",
-    "tslib": "^2.4.1"
+    "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@croct/eslint-plugin": "^0.6.3",
+    "@croct/eslint-plugin": "^0.6.6",
     "@types/jest": "^29.2.3",
     "eslint": "^8.27.0",
     "fetch-mock": "^9.11.0",

--- a/src/cid/assigner.ts
+++ b/src/cid/assigner.ts
@@ -1,3 +1,3 @@
 export interface CidAssigner {
-    assignCid(): Promise<string>;
+    assignCid(currentCid?: string): Promise<string>;
 }

--- a/src/cid/cachedAssigner.ts
+++ b/src/cid/cachedAssigner.ts
@@ -41,7 +41,7 @@ export class CachedAssigner implements CidAssigner {
         logger.debug('Using existing CID');
 
         if (cachedCid !== previousCid) {
-            logger.debug('Cached CID is stale, updating cache...');
+            logger.debug('The cached CID is stale, updating cache...');
 
             this.cache.put(previousCid);
         }

--- a/src/container.ts
+++ b/src/container.ts
@@ -256,24 +256,11 @@ export class Container {
             return new FixedAssigner('00000000-0000-0000-0000-000000000000');
         }
 
-        const cidKey = 'croct.cid';
-        const cache = this.getLocalStorage();
         const logger = this.getLogger('CidAssigner');
-        let endpoint = this.configuration.cidAssignerEndpointUrl;
-
-        if (this.configuration.refreshCid) {
-            const cachedCid = cache.getItem(cidKey);
-            const baseEndpoint = new URL(endpoint);
-
-            if (cachedCid !== null) {
-                baseEndpoint.searchParams.set('cid', cachedCid);
-                endpoint = baseEndpoint.toString();
-            }
-        }
 
         return new CachedAssigner(
-            new RemoteAssigner(endpoint.toString(), logger),
-            new LocalStorageCache(cache, cidKey),
+            new RemoteAssigner(this.configuration.cidAssignerEndpointUrl, logger),
+            new LocalStorageCache(this.getLocalStorage(), 'croct.cid'),
             {
                 logger: logger,
                 refresh: this.configuration.refreshCid,

--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -28,6 +28,7 @@ export type Configuration = {
     logger?: Logger,
     urlSanitizer?: UrlSanitizer,
     baseEndpointUrl?: string,
+    refreshCid?: boolean,
     cidAssignerEndpointUrl?: string,
 };
 
@@ -71,6 +72,7 @@ export class SdkFacade {
                 tokenScope: containerConfiguration.tokenScope ?? 'global',
                 debug: containerConfiguration.debug ?? false,
                 test: containerConfiguration.test ?? false,
+                refreshCid: containerConfiguration.refreshCid ?? false,
             }),
         );
 

--- a/src/schema/sdkFacadeSchemas.ts
+++ b/src/schema/sdkFacadeSchemas.ts
@@ -13,6 +13,7 @@ export const sdkFacadeConfigurationSchema = new ObjectType({
             pattern: /^[0-9a-f]{32}$/i,
         }),
         tokenScope: tokenScopeSchema,
+        refreshCid: new BooleanType(),
         debug: new BooleanType(),
         test: new BooleanType(),
         track: new BooleanType(),

--- a/src/schema/sdkSchemas.ts
+++ b/src/schema/sdkSchemas.ts
@@ -15,7 +15,7 @@ export const eventMetadataSchema = new ObjectType({
 });
 
 export const sdkConfigurationSchema = new ObjectType({
-    required: ['appId'],
+    required: ['appId', 'tokenScope', 'refreshCid', 'debug', 'test'],
     properties: {
         appId: new StringType({
             format: 'uuid',
@@ -34,6 +34,7 @@ export const sdkConfigurationSchema = new ObjectType({
             minimum: 0,
             integer: true,
         }),
+        refreshCid: new BooleanType(),
         debug: new BooleanType(),
         test: new BooleanType(),
         logger: loggerSchema,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -20,6 +20,7 @@ export type Configuration = {
     test: boolean,
     clientId?: string,
     baseEndpointUrl?: string,
+    refreshCid: boolean,
     cidAssignerEndpointUrl?: string,
     beaconQueueSize?: number,
     urlSanitizer?: UrlSanitizer,
@@ -52,6 +53,7 @@ export class Sdk {
         validateConfiguration(configuration);
 
         const {
+            refreshCid,
             eventMetadata: customMetadata = {},
             baseEndpointUrl = BASE_ENDPOINT_URL,
             cidAssignerEndpointUrl,
@@ -71,6 +73,7 @@ export class Sdk {
 
         const container = new Container({
             ...containerConfiguration,
+            refreshCid: refreshCid,
             evaluationBaseEndpointUrl: baseHttpEndpoint,
             contentBaseEndpointUrl: baseHttpEndpoint,
             trackerEndpointUrl: `${baseWsEndpoint}/client/web/connect`,

--- a/src/trackingEvents.ts
+++ b/src/trackingEvents.ts
@@ -7,7 +7,7 @@ import {DistributiveOmit, Optional} from './utilityTypes';
 
 export type ProductDetails = {
     productId: string,
-    productSku?: string,
+    sku?: string,
     name: string,
     category?: string,
     brand?: string,
@@ -144,7 +144,7 @@ type TwoLevelMap = {[member: string]: Primitive | PrimitiveMap | PrimitiveArray}
 type TwoLevelArray = PrimitiveArray | PrimitiveMap[] | PrimitiveArray[];
 type CustomAttribute = Primitive | TwoLevelMap | TwoLevelArray;
 
-type UserProfile = {
+export type UserProfile = {
     firstName?: string,
     lastName?: string,
     birthDate?: string,

--- a/test/cid/cachedAssigner.test.ts
+++ b/test/cid/cachedAssigner.test.ts
@@ -1,6 +1,6 @@
 import {CidAssigner, CachedAssigner} from '../../src/cid';
-import {NullLogger} from '../../src/logging';
 import {Cache, InMemoryCache} from '../../src/cache';
+import {Logger} from '../../src/logging';
 
 describe('A cached CID assigner', () => {
     afterEach(() => {
@@ -10,19 +10,39 @@ describe('A cached CID assigner', () => {
     it('should try to retrieve the CID from cache', async () => {
         const cache: Cache = new InMemoryCache();
         const underlyingAssigner: CidAssigner = {assignCid: jest.fn()};
-        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache);
+        const logger: Logger = {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
+            logger: logger,
+        });
 
         cache.put('123');
 
         await expect(cachedAssigner.assignCid()).resolves.toEqual('123');
 
         expect(underlyingAssigner.assignCid).not.toHaveBeenCalled();
+
+        expect(logger.debug).toHaveBeenCalledWith('Previous CID loaded from cache');
     });
 
     it('should assign and cache new CIDs', async () => {
         const underlyingAssigner: CidAssigner = {assignCid: jest.fn().mockResolvedValue('123')};
         const cache: Cache = new InMemoryCache();
-        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, new NullLogger());
+        const logger: Logger = {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
+            logger: logger,
+        });
 
         expect(cache.get()).toBeNull();
 
@@ -33,5 +53,63 @@ describe('A cached CID assigner', () => {
         await expect(cachedAssigner.assignCid()).resolves.toEqual('123');
 
         expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(1);
+
+        expect(logger.debug).toHaveBeenCalledWith('New CID stored into cache');
+    });
+
+    it('should refresh the CID if requested', async () => {
+        const underlyingAssigner: CidAssigner = {assignCid: jest.fn().mockResolvedValue('321')};
+        const cache: Cache = new InMemoryCache();
+        const logger: Logger = {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
+            logger: logger,
+            refresh: true,
+        });
+
+        cache.put('123');
+
+        await expect(cachedAssigner.assignCid()).resolves.toEqual('123');
+
+        expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(1);
+
+        expect(logger.debug).toHaveBeenCalledWith('Previous CID loaded from cache');
+
+        expect(logger.debug).toHaveBeenCalledWith('Refreshing CID');
+
+        await expect(cachedAssigner.assignCid()).resolves.toEqual('321');
+
+        expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(2);
+
+        expect(logger.warn).toHaveBeenCalledWith('The CID has changed, updating cache');
+    });
+
+    it('should handle errors when refreshing the CID', async () => {
+        const underlyingAssigner: CidAssigner = {assignCid: jest.fn().mockRejectedValue(new Error('Failed'))};
+        const cache: Cache = new InMemoryCache();
+        const logger: Logger = {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
+            logger: logger,
+            refresh: true,
+        });
+
+        cache.put('123');
+
+        await expect(cachedAssigner.assignCid()).resolves.toEqual('123');
+
+        expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(1);
+
+        expect(logger.error).toHaveBeenCalledWith('Failed to refresh CID');
     });
 });

--- a/test/cid/cachedAssigner.test.ts
+++ b/test/cid/cachedAssigner.test.ts
@@ -73,6 +73,8 @@ describe('A cached CID assigner', () => {
 
         await expect(cachedAssigner.assignCid()).resolves.toEqual('321');
 
+        expect(logger.debug).toHaveBeenCalledWith('The cached CID is stale, updating cache...');
+
         expect(underlyingAssigner.assignCid).not.toHaveBeenCalled();
     });
 

--- a/test/cid/cachedAssigner.test.ts
+++ b/test/cid/cachedAssigner.test.ts
@@ -27,7 +27,53 @@ describe('A cached CID assigner', () => {
 
         expect(underlyingAssigner.assignCid).not.toHaveBeenCalled();
 
-        expect(logger.debug).toHaveBeenCalledWith('Previous CID loaded from cache');
+        expect(logger.debug).toHaveBeenCalledWith('Using existing CID');
+    });
+
+    it('should try to use the current CID when available', async () => {
+        const cache: Cache = new InMemoryCache();
+        const underlyingAssigner: CidAssigner = {assignCid: jest.fn()};
+        const logger: Logger = {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
+            logger: logger,
+        });
+
+        await expect(cachedAssigner.assignCid('123')).resolves.toEqual('123');
+
+        // Ensure the cache is used at the second call
+        await expect(cachedAssigner.assignCid()).resolves.toEqual('123');
+
+        expect(underlyingAssigner.assignCid).not.toHaveBeenCalled();
+    });
+
+    it('should use the current CID over the cached CID', async () => {
+        const cache: Cache = new InMemoryCache();
+        const underlyingAssigner: CidAssigner = {assignCid: jest.fn()};
+
+        const logger: Logger = {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
+            logger: logger,
+        });
+
+        cache.put('123');
+
+        await expect(cachedAssigner.assignCid('321')).resolves.toEqual('321');
+
+        await expect(cachedAssigner.assignCid()).resolves.toEqual('321');
+
+        expect(underlyingAssigner.assignCid).not.toHaveBeenCalled();
     });
 
     it('should assign and cache new CIDs', async () => {
@@ -78,7 +124,7 @@ describe('A cached CID assigner', () => {
 
         expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(1);
 
-        expect(logger.debug).toHaveBeenCalledWith('Previous CID loaded from cache');
+        expect(logger.debug).toHaveBeenCalledWith('Using existing CID');
 
         expect(logger.debug).toHaveBeenCalledWith('Refreshing CID');
 
@@ -86,7 +132,60 @@ describe('A cached CID assigner', () => {
 
         expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(2);
 
-        expect(logger.warn).toHaveBeenCalledWith('The CID has changed, updating cache');
+        expect(logger.warn).toHaveBeenCalledWith('The CID has changed, updating cache...');
+    });
+
+    it('should pass the current CID to the underlying assigner', async () => {
+        const underlyingAssigner: CidAssigner = {
+            assignCid: jest.fn((cid: string) => Promise.resolve(cid)),
+        };
+
+        const cache: Cache = new InMemoryCache();
+        const logger: Logger = {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
+            logger: logger,
+            refresh: true,
+        });
+
+        // Make sure it will use the current CID and not the cached one
+        cache.put('456');
+
+        await expect(cachedAssigner.assignCid('123')).resolves.toEqual('123');
+
+        expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(1);
+        expect(underlyingAssigner.assignCid).toHaveBeenCalledWith('123');
+    });
+
+    it('should pass the cached CID to the underlying assigner', async () => {
+        const underlyingAssigner: CidAssigner = {
+            assignCid: jest.fn((cid: string) => Promise.resolve(cid)),
+        };
+
+        const cache: Cache = new InMemoryCache();
+        const logger: Logger = {
+            debug: jest.fn(),
+            warn: jest.fn(),
+            info: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
+            logger: logger,
+            refresh: true,
+        });
+
+        cache.put('123');
+
+        await expect(cachedAssigner.assignCid()).resolves.toEqual('123');
+
+        expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(1);
+        expect(underlyingAssigner.assignCid).toHaveBeenCalledWith('123');
     });
 
     it('should handle errors when refreshing the CID', async () => {

--- a/test/cid/remoteAssigner.test.ts
+++ b/test/cid/remoteAssigner.test.ts
@@ -75,4 +75,15 @@ describe('A remote CID assigner', () => {
 
         expect(done).toHaveBeenCalled();
     });
+
+    it('should pass the current CID to the endpoint', async () => {
+        const cachedAssigner = new RemoteAssigner(ENDPOINT);
+
+        fetchMock.mock({
+            ...requestMatcher,
+            matcher: `${ENDPOINT}?cid=321`,
+        });
+
+        await expect(cachedAssigner.assignCid('321')).resolves.toEqual('123');
+    });
 });

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -210,7 +210,7 @@ describe('A container', () => {
         await expect(assigner.assignCid()).resolves.toBe(cid);
     });
 
-    it('should refresh the CID when the refresh flag is enabled', async () => {
+    it('should refresh the CID passing the current CID as a query parameter', async () => {
         const cid = 'e6a133ffd3d2410681403d5e1bd95505';
         const endpoint = `${configuration.cidAssignerEndpointUrl}?cid=${cid}`;
 
@@ -255,6 +255,23 @@ describe('A container', () => {
         await expect(assigner.assignCid()).resolves.toBe(cid);
 
         expect(fetchMock.lastUrl()).toBeUndefined();
+    });
+
+    it('should not refresh the CID when there is no cached CID', async () => {
+        fetchMock.mock({
+            method: 'GET',
+            matcher: configuration.cidAssignerEndpointUrl,
+            response: '123',
+        });
+
+        const container = new Container({
+            ...configuration,
+            refreshCid: true,
+        });
+
+        const assigner = container.getCidAssigner();
+
+        await expect(assigner.assignCid()).resolves.toBe('123');
     });
 
     it('should configure a fixed CID assigner in test mode', async () => {

--- a/test/contentFetcher.test.ts
+++ b/test/contentFetcher.test.ts
@@ -488,6 +488,32 @@ describe('A content fetcher', () => {
         await expect(promise).rejects.toEqual(expect.objectContaining({response: response}));
     });
 
+    it('should catch unexpected error responses', async () => {
+        const fetcher = new ContentFetcher({
+            appId: appId,
+        });
+
+        const response: ErrorResponse = {
+            title: `Invalid json response body at ${BASE_ENDPOINT_URL}/client/web/content `
+                + 'reason: Unexpected token I in JSON at position 0',
+            type: ContentErrorType.UNEXPECTED_ERROR,
+            detail: 'Please try again or contact Croct support if the error persists.',
+            status: 500,
+        };
+
+        fetchMock.mock({
+            ...requestMatcher,
+            response: {
+                body: 'Invalid JSON payload',
+            },
+        });
+
+        const promise = fetcher.fetch(contentId);
+
+        await expect(promise).rejects.toThrow(ContentError);
+        await expect(promise).rejects.toEqual(expect.objectContaining({response: response}));
+    });
+
     it('should report unexpected errors when the cause of the fetch failure is unknown', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -450,6 +450,32 @@ describe('An evaluator', () => {
         await expect(promise).rejects.toEqual(expect.objectContaining({response: response}));
     });
 
+    it('should catch unexpected error responses', async () => {
+        const evaluator = new Evaluator({
+            appId: appId,
+        });
+
+        const response: ErrorResponse = {
+            title: `Invalid json response body at ${BASE_ENDPOINT_URL}/client/web/evaluate `
+                + 'reason: Unexpected token I in JSON at position 0',
+            type: EvaluationErrorType.UNEXPECTED_ERROR,
+            detail: 'Please try again or contact Croct support if the error persists.',
+            status: 500,
+        };
+
+        fetchMock.mock({
+            ...requestMatcher,
+            response: {
+                body: 'Invalid JSON payload',
+            },
+        });
+
+        const promise = evaluator.evaluate(query);
+
+        await expect(promise).rejects.toThrow(EvaluationError);
+        await expect(promise).rejects.toEqual(expect.objectContaining({response: response}));
+    });
+
     it('should report unexpected errors when the cause of the evaluation failure is unknown', async () => {
         const evaluator = new Evaluator({
             appId: appId,

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -88,12 +88,15 @@ describe('A SDK facade', () => {
 
         SdkFacade.init({appId: appId});
 
-        expect(initialize).toHaveBeenCalledWith({
-            appId: appId,
-            tokenScope: 'global',
-            debug: false,
-            test: false,
-        });
+        expect(initialize).toHaveBeenCalledWith(
+            {
+                appId: appId,
+                tokenScope: 'global',
+                refreshCid: false,
+                debug: false,
+                test: false,
+            } satisfies Configuration,
+        );
     });
 
     it('should load the SDK using the specified configuration', () => {
@@ -115,16 +118,19 @@ describe('A SDK facade', () => {
             urlSanitizer: urlSanitizer,
         });
 
-        expect(initialize).toHaveBeenCalledWith({
-            appId: appId,
-            baseEndpointUrl: 'https://api.croct.io',
-            cidAssignerEndpointUrl: 'https://api.croct.io/cid',
-            debug: false,
-            test: false,
-            tokenScope: 'isolated',
-            logger: logger,
-            urlSanitizer: urlSanitizer,
-        });
+        expect(initialize).toHaveBeenCalledWith(
+            {
+                appId: appId,
+                baseEndpointUrl: 'https://api.croct.io',
+                cidAssignerEndpointUrl: 'https://api.croct.io/cid',
+                refreshCid: false,
+                debug: false,
+                test: false,
+                tokenScope: 'isolated',
+                logger: logger,
+                urlSanitizer: urlSanitizer,
+            } satisfies Configuration,
+        );
     });
 
     it('should load the SDK and set the provided token', () => {

--- a/test/schemas/contentFetcherSchemas.test.ts
+++ b/test/schemas/contentFetcherSchemas.test.ts
@@ -1,7 +1,8 @@
 import {fetchOptionsSchema} from '../../src/schema';
+import {FetchOptions} from '../../src/facade/contentFetcherFacade';
 
 describe('The content fetcher option schema', () => {
-    it.each([
+    it.each<FetchOptions[]>([
         [{}],
         [{
             timeout: 1,
@@ -37,7 +38,7 @@ describe('The content fetcher option schema', () => {
             timeout: 1,
             attributes: {foo: 'bar'},
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             fetchOptionsSchema.validate(value);
         }

--- a/test/schemas/contentSchemas.test.ts
+++ b/test/schemas/contentSchemas.test.ts
@@ -1,7 +1,8 @@
 import {postDetails} from '../../src/schema/contentSchemas';
+import {PostDetails} from '../../src/trackingEvents';
 
 describe('The product details schema', () => {
-    it.each([
+    it.each<PostDetails[]>([
         [{
             postId: 'post-id',
             title: 'post-title',
@@ -17,7 +18,7 @@ describe('The product details schema', () => {
             publishTime: 0,
             updateTime: 1,
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             postDetails.validate(value);
         }

--- a/test/schemas/contextSchemas.test.ts
+++ b/test/schemas/contextSchemas.test.ts
@@ -1,5 +1,5 @@
 import {tokenScopeSchema} from '../../src/schema';
-import {TokenScope} from '../../build/context';
+import {TokenScope} from '../../src/context';
 
 describe('The token schema', () => {
     it.each<TokenScope[]>([

--- a/test/schemas/contextSchemas.test.ts
+++ b/test/schemas/contextSchemas.test.ts
@@ -1,11 +1,12 @@
 import {tokenScopeSchema} from '../../src/schema';
+import {TokenScope} from '../../build/context';
 
 describe('The token schema', () => {
-    it.each([
+    it.each<TokenScope[]>([
         ['global'],
         ['contextual'],
         ['isolated'],
-    ])('should allow the value "%s"', (value: string) => {
+    ])('should allow the value "%s"', value => {
         function validate(): void {
             tokenScopeSchema.validate(value);
         }

--- a/test/schemas/ecommerceSchemas.test.ts
+++ b/test/schemas/ecommerceSchemas.test.ts
@@ -7,23 +7,27 @@ const minimalProductDetails: ProductDetails = {
     name: 'Smartphone 9',
     displayPrice: 599.00,
 };
+
 const minimalCartItem: CartItem = {
     index: 0,
     total: 699.00,
     quantity: 1,
     product: minimalProductDetails,
 };
+
 const minimalCart: Optional<Cart, 'lastUpdateTime'> = {
     currency: 'brl',
     total: 776.49,
     items: [minimalCartItem],
 };
+
 const minimalOrderItem: OrderItem = {
     index: 0,
     total: 699.00,
     quantity: 1,
     product: minimalProductDetails,
 };
+
 const minimalOrder: Order = {
     orderId: 'b76c0ef6-9520-4107-9de3-11110829588e',
     currency: 'brl',
@@ -32,7 +36,7 @@ const minimalOrder: Order = {
 };
 
 describe('The product details schema', () => {
-    it.each([
+    it.each<ProductDetails[]>([
         [minimalProductDetails],
         [{
             productId: '12345',
@@ -46,7 +50,7 @@ describe('The product details schema', () => {
             url: 'https://www.acme.com/product/smartphone9',
             imageUrl: 'https://www.acme.com/images/smartphone9-64gb-green',
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             productDetails.validate(value);
         }
@@ -141,7 +145,7 @@ describe('The product details schema', () => {
 });
 
 describe('The cart item schema', () => {
-    it.each([
+    it.each<CartItem[]>([
         [minimalCartItem],
         [{
             index: 0,
@@ -151,7 +155,7 @@ describe('The cart item schema', () => {
             coupon: 'PROMO',
             product: minimalProductDetails,
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', (value: CartItem) => {
         function validate(): void {
             cartItem.validate(value);
         }
@@ -259,7 +263,7 @@ describe('The cart item schema', () => {
 });
 
 describe('The cart schema', () => {
-    it.each([
+    it.each<Array<Optional<Cart, 'lastUpdateTime'>>>([
         [minimalCart],
         [{
             currency: 'brl',
@@ -296,7 +300,7 @@ describe('The cart schema', () => {
             coupon: 'FREE-SHIPPING',
             lastUpdateTime: 123456789,
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             cart.validate(value);
         }
@@ -468,7 +472,7 @@ describe('The cart schema', () => {
 });
 
 describe('The order item schema', () => {
-    it.each([
+    it.each<OrderItem[]>([
         [minimalOrderItem],
         [{
             index: 0,
@@ -478,7 +482,7 @@ describe('The order item schema', () => {
             coupon: 'PROMO',
             product: minimalProductDetails,
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             orderItem.validate(value);
         }
@@ -586,7 +590,7 @@ describe('The order item schema', () => {
 });
 
 describe('The order schema', () => {
-    it.each([
+    it.each<Order[]>([
         [minimalOrder],
         [{
             orderId: 'b76c0ef6-9520-4107-9de3-11110829588e',
@@ -648,7 +652,7 @@ describe('The order schema', () => {
             installments: 1,
             status: 'paid',
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             order.validate(value);
         }

--- a/test/schemas/evaluationSchemas.test.ts
+++ b/test/schemas/evaluationSchemas.test.ts
@@ -1,7 +1,8 @@
 import {evaluationOptionsSchema} from '../../src/schema';
+import {EvaluationOptions} from '../../src/facade/evaluatorFacade';
 
 describe('The evaluation option schema', () => {
-    it.each([
+    it.each<EvaluationOptions[]>([
         [{}],
         [{
             timeout: 1,
@@ -13,7 +14,7 @@ describe('The evaluation option schema', () => {
             timeout: 1,
             attributes: {foo: 'bar'},
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             evaluationOptionsSchema.validate(value);
         }

--- a/test/schemas/eventSchemas.test.ts
+++ b/test/schemas/eventSchemas.test.ts
@@ -1,4 +1,16 @@
-import {Cart, CartItem, Order, OrderItem, ProductDetails} from '../../src/trackingEvents';
+import {
+    Cart,
+    CartItem,
+    ExternalTrackingEvent,
+    GoalCompleted,
+    InterestShown,
+    LinkOpened,
+    Order,
+    OrderItem,
+    PostViewed,
+    ProductDetails,
+    EventOccurred,
+} from '../../src/trackingEvents';
 import {
     cartViewed,
     cartModified,
@@ -19,23 +31,27 @@ const minimalProductDetails: ProductDetails = {
     name: 'Smartphone 9',
     displayPrice: 599.00,
 };
+
 const minimalCartItem: CartItem = {
     index: 0,
     total: 699.00,
     quantity: 1,
     product: minimalProductDetails,
 };
+
 const minimalCart: Optional<Cart, 'lastUpdateTime'> = {
     currency: 'brl',
     total: 776.49,
     items: [minimalCartItem],
 };
+
 const minimalOrderItem: OrderItem = {
     index: 0,
     total: 699.00,
     quantity: 1,
     product: minimalProductDetails,
 };
+
 const minimalOrder: Order = {
     orderId: 'b76c0ef6-9520-4107-9de3-11110829588e',
     currency: 'brl',
@@ -80,10 +96,10 @@ describe('The "cartViewed" payload schema', () => {
 });
 
 describe('The "checkoutStarted" payload schema', () => {
-    it.each([
+    it.each<Array<Omit<ExternalTrackingEvent<'checkoutStarted'>, 'type'>>>([
         [{cart: minimalCart}],
         [{cart: minimalCart, orderId: 'b76c0ef6-9520-4107-9de3-11110829588e'}],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             checkoutStarted.validate(value);
         }
@@ -150,7 +166,7 @@ describe('The "productViewed" payload schema', () => {
 });
 
 describe('The "userSignedUp" payload schema', () => {
-    it.each([
+    it.each<Array<Omit<ExternalTrackingEvent<'userSignedUp'>, 'type'>>>([
         [{
             userId: '1ed2fd65-a027-4f3a-a35f-c6dd97537392',
         }],
@@ -158,7 +174,7 @@ describe('The "userSignedUp" payload schema', () => {
             userId: '1ed2fd65-a027-4f3a-a35f-c6dd97537392',
             profile: {firstName: 'John'},
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             userSignedUp.validate(value);
         }
@@ -193,7 +209,7 @@ describe('The "userSignedUp" payload schema', () => {
 });
 
 describe('The "eventOccurred" payload schema', () => {
-    it.each([
+    it.each<Array<Omit<EventOccurred, 'type'>>>([
         [{
             name: 'foo',
         }],
@@ -210,7 +226,7 @@ describe('The "eventOccurred" payload schema', () => {
                 boolean: true,
             },
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             eventOccurred.validate(value);
         }
@@ -336,7 +352,7 @@ describe('The "eventOccurred" payload schema', () => {
 });
 
 describe('The "goalCompleted" payload schema', () => {
-    it.each([
+    it.each<Array<Omit<GoalCompleted, 'type'>>>([
         [{
             goalId: 'foo:bar-baz_123',
         }],
@@ -357,7 +373,7 @@ describe('The "goalCompleted" payload schema', () => {
             value: 1,
             currency: 'brl',
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             goalCompleted.validate(value);
         }
@@ -444,14 +460,14 @@ describe('The "goalCompleted" payload schema', () => {
 });
 
 describe('The "interestShown" payload schema', () => {
-    it.each([
+    it.each<Array<Omit<InterestShown, 'type'>>>([
         [{
             interests: ['foo'],
         }],
         [{
             interests: new Array(10).fill('x'),
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             interestShown.validate(value);
         }
@@ -490,7 +506,7 @@ describe('The "interestShown" payload schema', () => {
 });
 
 describe('The "postViewed" payload schema', () => {
-    it.each([
+    it.each<Array<Omit<PostViewed, 'type'>>>([
         [{
             post: {
                 postId: 'post-id',
@@ -498,7 +514,7 @@ describe('The "postViewed" payload schema', () => {
                 publishTime: 0,
             },
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             postViewed.validate(value);
         }
@@ -525,7 +541,7 @@ describe('The "postViewed" payload schema', () => {
 });
 
 describe('The "linkOpened" payload schema', () => {
-    it.each([
+    it.each<Array<Omit<LinkOpened, 'type'>>>([
         [{
             link: 'http://www.foo.com.br',
         }],

--- a/test/schemas/sdkFacadeSchemas.test.ts
+++ b/test/schemas/sdkFacadeSchemas.test.ts
@@ -1,7 +1,8 @@
 import {sdkFacadeConfigurationSchema} from '../../src/schema';
+import {Configuration} from '../../src/facade/sdkFacade';
 
 describe('The SDK facade configuration schema', () => {
-    it.each([
+    it.each<Configuration[]>([
         [{
             appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
         }],
@@ -28,6 +29,7 @@ describe('The SDK facade configuration schema', () => {
             tokenScope: 'isolated',
             userId: 'c4r0l',
             token: 'a.b.c',
+            refreshCid: true,
             debug: true,
             test: true,
             track: true,
@@ -38,7 +40,7 @@ describe('The SDK facade configuration schema', () => {
                 error: jest.fn(),
             },
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             sdkFacadeConfigurationSchema.validate(value);
         }
@@ -94,6 +96,10 @@ describe('The SDK facade configuration schema', () => {
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', track: 'foo'},
             "Expected value of type boolean at path '/track', actual string.",
+        ],
+        [
+            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', refreshCid: 'foo'},
+            "Expected value of type boolean at path '/refreshCid', actual string.",
         ],
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', logger: null},

--- a/test/schemas/sdkSchemas.test.ts
+++ b/test/schemas/sdkSchemas.test.ts
@@ -1,4 +1,5 @@
 import {sdkConfigurationSchema, eventMetadataSchema} from '../../src/schema';
+import {Configuration} from '../../src';
 
 describe('The event metadata schema', () => {
     it.each([
@@ -64,13 +65,13 @@ describe('The event metadata schema', () => {
 });
 
 describe('The SDK configuration schema', () => {
-    it.each([
-        [{
-            appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
-        }],
+    it.each<Configuration[]>([
         [{
             appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
             tokenScope: 'global',
+            refreshCid: true,
+            debug: true,
+            test: true,
         }],
         [{
             appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
@@ -79,6 +80,7 @@ describe('The SDK configuration schema', () => {
             baseEndpointUrl: 'https://api.croct.io',
             cidAssignerEndpointUrl: 'https://api.croct.io/cid',
             beaconQueueSize: 1,
+            refreshCid: true,
             debug: true,
             test: true,
             logger: {
@@ -89,7 +91,7 @@ describe('The SDK configuration schema', () => {
             },
             eventMetadata: {},
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             sdkConfigurationSchema.validate(value);
         }
@@ -99,47 +101,146 @@ describe('The SDK configuration schema', () => {
 
     it.each([
         [
-            {},
+            {
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: true,
+            },
             "Missing property '/appId'.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', clientId: '7e9d59a9'},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                refreshCid: true,
+                debug: true,
+                test: true,
+            },
+            "Missing property '/tokenScope'.",
+        ],
+        [
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                debug: true,
+                test: true,
+            },
+            "Missing property '/refreshCid'.",
+        ],
+        [
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                test: true,
+            },
+            "Missing property '/debug'.",
+        ],
+        [
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: true,
+                clientId: '7e9d59a9',
+            },
             "Invalid format at path '/clientId'.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', tokenScope: 'x'},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                refreshCid: true,
+                debug: true,
+                test: true,
+                tokenScope: 'x',
+            },
             "Unexpected value at path '/tokenScope', expecting 'global', 'contextual' or 'isolated', found 'x'.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', debug: 'foo'},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                test: true,
+                debug: 'foo',
+            },
             "Expected value of type boolean at path '/debug', actual string.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', test: 'foo'},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: 'foo',
+            },
             "Expected value of type boolean at path '/test', actual string.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', baseEndpointUrl: 'foo'},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: true,
+                baseEndpointUrl: 'foo',
+            },
             "Invalid url format at path '/baseEndpointUrl'.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', cidAssignerEndpointUrl: 'foo'},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: true,
+                cidAssignerEndpointUrl: 'foo',
+            },
             "Invalid url format at path '/cidAssignerEndpointUrl'.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', beaconQueueSize: -1},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: true,
+                beaconQueueSize: -1,
+            },
             "Expected a value greater than or equal to 0 at path '/beaconQueueSize', actual -1.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', beaconQueueSize: 1.2},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: true,
+                beaconQueueSize: 1.2,
+            },
             "Expected value of type integer at path '/beaconQueueSize', actual number.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', eventMetadata: {foo: 1}},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: true,
+                eventMetadata: {foo: 1},
+            },
             "Expected value of type string at path '/eventMetadata/foo', actual integer.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', logger: null},
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                refreshCid: true,
+                debug: true,
+                test: true,
+                logger: null,
+            },
             "Expected value of type object at path '/logger', actual null.",
         ],
     ])('should not allow %s', (value: Record<string, unknown>, message: string) => {

--- a/test/schemas/tokenSchema.test.ts
+++ b/test/schemas/tokenSchema.test.ts
@@ -1,7 +1,14 @@
 import {tokenSchema} from '../../src/schema';
+import {TokenPayload, Headers} from '../../src/token';
+
+type ParsedToken = {
+    headers: Headers,
+    payload: TokenPayload,
+    signature?: string,
+};
 
 describe('The token schema', () => {
-    it.each([
+    it.each<ParsedToken[]>([
         [{
             headers: {
                 typ: 'JWT',
@@ -55,7 +62,7 @@ describe('The token schema', () => {
                 },
             },
         }],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             tokenSchema.validate(value);
         }

--- a/test/schemas/userSchema.test.ts
+++ b/test/schemas/userSchema.test.ts
@@ -1,7 +1,8 @@
 import {userProfileSchema} from '../../src/schema';
+import {UserProfile} from '../../src/trackingEvents';
 
 describe('The user profile schema', () => {
-    it.each([
+    it.each<UserProfile[]>([
         [{firstName: 'x'}],
         [{firstName: 'x'.repeat(50)}],
         [{lastName: 'x'}],
@@ -101,7 +102,7 @@ describe('The user profile schema', () => {
         [{custom: {nestedArrayInMap: {foo: [1, 2, 3]}}}],
         [{custom: {nestedMapInArray: [{foo: 'bar'}]}}],
         [{custom: {nestedMapInMap: {foo: {bar: 'baz'}}}}],
-    ])('should allow %s', (value: Record<string, unknown>) => {
+    ])('should allow %s', value => {
         function validate(): void {
             userProfileSchema.validate(value);
         }

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -24,6 +24,7 @@ describe('A SDK', () => {
         clientId: 'e6a133ffd3d2410681403d5e1bd95505',
         tokenScope: 'global',
         beaconQueueSize: 3,
+        refreshCid: false,
         debug: true,
         test: false,
         logger: new NullLogger(),
@@ -263,6 +264,7 @@ describe('A SDK', () => {
             appId: configuration.appId,
             cidAssignerEndpointUrl: configuration.cidAssignerEndpointUrl,
             tokenScope: configuration.tokenScope,
+            refreshCid: false,
             debug: false,
             test: false,
         });
@@ -286,6 +288,7 @@ describe('A SDK', () => {
                 appId: configuration.appId,
                 tokenScope: configuration.tokenScope,
                 ...(baseEndpoint !== undefined ? {baseEndpointUrl: baseEndpoint} : {}),
+                refreshCid: false,
                 debug: false,
                 test: false,
             });


### PR DESCRIPTION
## Summary
This PR adds support for migrating from 3rd party cookies to 1st party cookies.

When passing `refreshCid: true`, the CID assigner will request a new CID even when there is a CID in the cache. Backends can then get the CID from the query string parameter and store it in cookies for later visits (overriding existing ones).

This option is recommended for a migration window only, reason why it's `false` by default. After that period, turning it off is recommended to avoid unnecessary requests.

It also improves coverage and fixes some typing issues.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings