### PR TITLE
Change userSignedUp operation from set to merge

### DIFF
--- a/src/tracker.ts
+++ b/src/tracker.ts
@@ -428,7 +428,7 @@ export class Tracker {
                 patch: {
                     operations: [
                         {
-                            type: 'set',
+                            type: 'merge',
                             path: '.',
                             value: profile,
                         },

--- a/test/tracker.test.ts
+++ b/test/tracker.test.ts
@@ -1001,7 +1001,7 @@ describe('A tracker', () => {
                 patch: {
                     operations: [
                         {
-                            type: 'set',
+                            type: 'merge',
                             path: '.',
                             value: {
                                 firstName: 'John',


### PR DESCRIPTION
## Summary

The `userSignedUp` event should use a merge operation since the user can have other information on their profile before signing up. Therefore, this PR replaces the set operation with the merge operation.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings