### PR TITLE
Change flag refreshCid to disableCidMirroring

### DIFF
--- a/src/cid/cachedAssigner.ts
+++ b/src/cid/cachedAssigner.ts
@@ -4,7 +4,7 @@ import {CidAssigner} from './assigner';
 
 type CachedAssignerOptions = {
     logger?: Logger,
-    refresh?: boolean,
+    mirror?: boolean,
 };
 
 export class CachedAssigner implements CidAssigner {
@@ -19,14 +19,14 @@ export class CachedAssigner implements CidAssigner {
         this.cache = cache;
         this.options = {
             logger: options.logger ?? new NullLogger(),
-            refresh: options.refresh ?? false,
+            mirror: options.mirror ?? false,
         };
     }
 
     public async assignCid(currentCid?: string): Promise<string> {
         const cachedCid = this.cache.get();
         const previousCid = currentCid ?? cachedCid ?? null;
-        const {logger, refresh} = this.options;
+        const {logger, mirror} = this.options;
 
         if (previousCid === null) {
             const newCid = await this.assigner.assignCid();
@@ -46,8 +46,8 @@ export class CachedAssigner implements CidAssigner {
             this.cache.put(previousCid);
         }
 
-        if (refresh) {
-            logger.debug('Refreshing CID');
+        if (mirror) {
+            logger.debug('Mirroring CID');
 
             this.assigner
                 .assignCid(previousCid)
@@ -59,7 +59,7 @@ export class CachedAssigner implements CidAssigner {
                     }
                 })
                 .catch(() => {
-                    logger.error('Failed to refresh CID');
+                    logger.error('Failed to mirror CID');
                 });
         }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -32,7 +32,7 @@ export type Configuration = {
     clientId?: string,
     debug: boolean,
     test: boolean,
-    refreshCid: boolean,
+    disableCidMirroring: boolean,
     cidAssignerEndpointUrl: string,
     trackerEndpointUrl: string,
     evaluationBaseEndpointUrl: string,
@@ -263,7 +263,7 @@ export class Container {
             new LocalStorageCache(this.getLocalStorage(), 'croct.cid'),
             {
                 logger: logger,
-                refresh: this.configuration.refreshCid,
+                mirror: !this.configuration.disableCidMirroring,
             },
         );
     }

--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -28,7 +28,7 @@ export type Configuration = {
     logger?: Logger,
     urlSanitizer?: UrlSanitizer,
     baseEndpointUrl?: string,
-    refreshCid?: boolean,
+    disableCidMirroring?: boolean,
     cidAssignerEndpointUrl?: string,
 };
 
@@ -72,7 +72,7 @@ export class SdkFacade {
                 tokenScope: containerConfiguration.tokenScope ?? 'global',
                 debug: containerConfiguration.debug ?? false,
                 test: containerConfiguration.test ?? false,
-                refreshCid: containerConfiguration.refreshCid ?? false,
+                disableCidMirroring: containerConfiguration.disableCidMirroring ?? false,
             }),
         );
 

--- a/src/schema/sdkFacadeSchemas.ts
+++ b/src/schema/sdkFacadeSchemas.ts
@@ -13,7 +13,7 @@ export const sdkFacadeConfigurationSchema = new ObjectType({
             pattern: /^[0-9a-f]{32}$/i,
         }),
         tokenScope: tokenScopeSchema,
-        refreshCid: new BooleanType(),
+        disableCidMirroring: new BooleanType(),
         debug: new BooleanType(),
         test: new BooleanType(),
         track: new BooleanType(),

--- a/src/schema/sdkSchemas.ts
+++ b/src/schema/sdkSchemas.ts
@@ -15,7 +15,7 @@ export const eventMetadataSchema = new ObjectType({
 });
 
 export const sdkConfigurationSchema = new ObjectType({
-    required: ['appId', 'tokenScope', 'refreshCid', 'debug', 'test'],
+    required: ['appId', 'tokenScope', 'disableCidMirroring', 'debug', 'test'],
     properties: {
         appId: new StringType({
             format: 'uuid',
@@ -34,7 +34,7 @@ export const sdkConfigurationSchema = new ObjectType({
             minimum: 0,
             integer: true,
         }),
-        refreshCid: new BooleanType(),
+        disableCidMirroring: new BooleanType(),
         debug: new BooleanType(),
         test: new BooleanType(),
         logger: loggerSchema,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -20,7 +20,7 @@ export type Configuration = {
     test: boolean,
     clientId?: string,
     baseEndpointUrl?: string,
-    refreshCid: boolean,
+    disableCidMirroring: boolean,
     cidAssignerEndpointUrl?: string,
     beaconQueueSize?: number,
     urlSanitizer?: UrlSanitizer,
@@ -53,7 +53,7 @@ export class Sdk {
         validateConfiguration(configuration);
 
         const {
-            refreshCid,
+            disableCidMirroring,
             eventMetadata: customMetadata = {},
             baseEndpointUrl = BASE_ENDPOINT_URL,
             cidAssignerEndpointUrl,
@@ -73,7 +73,7 @@ export class Sdk {
 
         const container = new Container({
             ...containerConfiguration,
-            refreshCid: refreshCid,
+            disableCidMirroring: disableCidMirroring,
             evaluationBaseEndpointUrl: baseHttpEndpoint,
             contentBaseEndpointUrl: baseHttpEndpoint,
             trackerEndpointUrl: `${baseWsEndpoint}/client/web/connect`,

--- a/test/cid/cachedAssigner.test.ts
+++ b/test/cid/cachedAssigner.test.ts
@@ -117,7 +117,7 @@ describe('A cached CID assigner', () => {
 
         const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
             logger: logger,
-            refresh: true,
+            mirror: true,
         });
 
         cache.put('123');
@@ -128,7 +128,7 @@ describe('A cached CID assigner', () => {
 
         expect(logger.debug).toHaveBeenCalledWith('Using existing CID');
 
-        expect(logger.debug).toHaveBeenCalledWith('Refreshing CID');
+        expect(logger.debug).toHaveBeenCalledWith('Mirroring CID');
 
         await expect(cachedAssigner.assignCid()).resolves.toEqual('321');
 
@@ -152,7 +152,7 @@ describe('A cached CID assigner', () => {
 
         const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
             logger: logger,
-            refresh: true,
+            mirror: true,
         });
 
         // Make sure it will use the current CID and not the cached one
@@ -179,7 +179,7 @@ describe('A cached CID assigner', () => {
 
         const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
             logger: logger,
-            refresh: true,
+            mirror: true,
         });
 
         cache.put('123');
@@ -202,7 +202,7 @@ describe('A cached CID assigner', () => {
 
         const cachedAssigner = new CachedAssigner(underlyingAssigner, cache, {
             logger: logger,
-            refresh: true,
+            mirror: true,
         });
 
         cache.put('123');
@@ -211,6 +211,6 @@ describe('A cached CID assigner', () => {
 
         expect(underlyingAssigner.assignCid).toHaveBeenCalledTimes(1);
 
-        expect(logger.error).toHaveBeenCalledWith('Failed to refresh CID');
+        expect(logger.error).toHaveBeenCalledWith('Failed to mirror CID');
     });
 });

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -25,7 +25,7 @@ describe('A container', () => {
         beaconQueueSize: 3,
         debug: false,
         test: false,
-        refreshCid: false,
+        disableCidMirroring: false,
         cidAssignerEndpointUrl: 'https://localtest/cid',
         contentBaseEndpointUrl: 'https://localtest/content',
         evaluationBaseEndpointUrl: 'https://localtest/evaluate',
@@ -224,7 +224,7 @@ describe('A container', () => {
 
         const container = new Container({
             ...configuration,
-            refreshCid: true,
+            disableCidMirroring: false,
         });
 
         const assigner = container.getCidAssigner();
@@ -247,7 +247,7 @@ describe('A container', () => {
 
         const container = new Container({
             ...configuration,
-            refreshCid: false,
+            disableCidMirroring: false,
         });
 
         const assigner = container.getCidAssigner();
@@ -266,7 +266,7 @@ describe('A container', () => {
 
         const container = new Container({
             ...configuration,
-            refreshCid: true,
+            disableCidMirroring: false,
         });
 
         const assigner = container.getCidAssigner();

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -92,7 +92,7 @@ describe('A SDK facade', () => {
             {
                 appId: appId,
                 tokenScope: 'global',
-                refreshCid: false,
+                disableCidMirroring: false,
                 debug: false,
                 test: false,
             } satisfies Configuration,
@@ -123,7 +123,7 @@ describe('A SDK facade', () => {
                 appId: appId,
                 baseEndpointUrl: 'https://api.croct.io',
                 cidAssignerEndpointUrl: 'https://api.croct.io/cid',
-                refreshCid: false,
+                disableCidMirroring: false,
                 debug: false,
                 test: false,
                 tokenScope: 'isolated',

--- a/test/schemas/sdkFacadeSchemas.test.ts
+++ b/test/schemas/sdkFacadeSchemas.test.ts
@@ -29,7 +29,7 @@ describe('The SDK facade configuration schema', () => {
             tokenScope: 'isolated',
             userId: 'c4r0l',
             token: 'a.b.c',
-            refreshCid: true,
+            disableCidMirroring: true,
             debug: true,
             test: true,
             track: true,
@@ -98,8 +98,8 @@ describe('The SDK facade configuration schema', () => {
             "Expected value of type boolean at path '/track', actual string.",
         ],
         [
-            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', refreshCid: 'foo'},
-            "Expected value of type boolean at path '/refreshCid', actual string.",
+            {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', disableCidMirroring: 'foo'},
+            "Expected value of type boolean at path '/disableCidMirroring', actual string.",
         ],
         [
             {appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a', logger: null},

--- a/test/schemas/sdkSchemas.test.ts
+++ b/test/schemas/sdkSchemas.test.ts
@@ -69,7 +69,7 @@ describe('The SDK configuration schema', () => {
         [{
             appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
             tokenScope: 'global',
-            refreshCid: true,
+            disableCidMirroring: true,
             debug: true,
             test: true,
         }],
@@ -80,7 +80,7 @@ describe('The SDK configuration schema', () => {
             baseEndpointUrl: 'https://api.croct.io',
             cidAssignerEndpointUrl: 'https://api.croct.io/cid',
             beaconQueueSize: 1,
-            refreshCid: true,
+            disableCidMirroring: true,
             debug: true,
             test: true,
             logger: {
@@ -103,7 +103,7 @@ describe('The SDK configuration schema', () => {
         [
             {
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
             },
@@ -112,7 +112,7 @@ describe('The SDK configuration schema', () => {
         [
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
             },
@@ -125,13 +125,13 @@ describe('The SDK configuration schema', () => {
                 debug: true,
                 test: true,
             },
-            "Missing property '/refreshCid'.",
+            "Missing property '/disableCidMirroring'.",
         ],
         [
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 test: true,
             },
             "Missing property '/debug'.",
@@ -140,7 +140,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
                 clientId: '7e9d59a9',
@@ -150,7 +150,7 @@ describe('The SDK configuration schema', () => {
         [
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
                 tokenScope: 'x',
@@ -161,7 +161,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 test: true,
                 debug: 'foo',
             },
@@ -171,7 +171,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: 'foo',
             },
@@ -181,7 +181,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
                 baseEndpointUrl: 'foo',
@@ -192,7 +192,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
                 cidAssignerEndpointUrl: 'foo',
@@ -203,7 +203,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
                 beaconQueueSize: -1,
@@ -214,7 +214,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
                 beaconQueueSize: 1.2,
@@ -225,7 +225,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
                 eventMetadata: {foo: 1},
@@ -236,7 +236,7 @@ describe('The SDK configuration schema', () => {
             {
                 appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
                 tokenScope: 'global',
-                refreshCid: true,
+                disableCidMirroring: true,
                 debug: true,
                 test: true,
                 logger: null,

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -24,7 +24,7 @@ describe('A SDK', () => {
         clientId: 'e6a133ffd3d2410681403d5e1bd95505',
         tokenScope: 'global',
         beaconQueueSize: 3,
-        refreshCid: false,
+        disableCidMirroring: false,
         debug: true,
         test: false,
         logger: new NullLogger(),
@@ -264,7 +264,7 @@ describe('A SDK', () => {
             appId: configuration.appId,
             cidAssignerEndpointUrl: configuration.cidAssignerEndpointUrl,
             tokenScope: configuration.tokenScope,
-            refreshCid: false,
+            disableCidMirroring: false,
             debug: false,
             test: false,
         });
@@ -288,7 +288,7 @@ describe('A SDK', () => {
                 appId: configuration.appId,
                 tokenScope: configuration.tokenScope,
                 ...(baseEndpoint !== undefined ? {baseEndpointUrl: baseEndpoint} : {}),
-                refreshCid: false,
+                disableCidMirroring: false,
                 debug: false,
                 test: false,
             });


### PR DESCRIPTION
## Summary

Change flag `refreshCid` to `disableCidMirroring`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings