### PR TITLE
Use X-Client-Agent instead User-Agent

### DIFF
--- a/src/contentFetcher.ts
+++ b/src/contentFetcher.ts
@@ -51,7 +51,7 @@ export type DynamicContentOptions = BasicOptions & {
     static?: false,
     clientId?: string,
     clientIp?: string,
-    userAgent?: string,
+    clientAgent?: string,
     userToken?: Token|string,
     previewToken?: Token|string,
     context?: EvaluationContext,
@@ -203,8 +203,8 @@ export class ContentFetcher {
                 headers['X-Token'] = options.userToken.toString();
             }
 
-            if (options.userAgent !== undefined) {
-                headers['User-Agent'] = options.userAgent;
+            if (options.clientAgent !== undefined) {
+                headers['X-Client-Agent'] = options.clientAgent;
             }
 
             if (options.context !== undefined) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -34,7 +34,7 @@ type ExtraFetchOptions<T extends keyof RequestInit = AllowedFetchOptions> = Pick
 export type EvaluationOptions = {
     clientId?: string,
     clientIp?: string,
-    userAgent?: string,
+    clientAgent?: string,
     userToken?: Token|string,
     timeout?: number,
     context?: EvaluationContext,
@@ -215,7 +215,7 @@ export class Evaluator {
 
     private fetch(body: JsonObject, signal: AbortSignal, options: EvaluationOptions): Promise<Response> {
         const {appId, apiKey} = this.configuration;
-        const {clientId, clientIp, userAgent, userToken} = options;
+        const {clientId, clientIp, clientAgent, userToken} = options;
 
         const headers: Record<string, string> = {
             'Content-Type': 'application/json',
@@ -241,8 +241,8 @@ export class Evaluator {
             headers['X-Token'] = userToken.toString();
         }
 
-        if (userAgent !== undefined) {
-            headers['User-Agent'] = userAgent;
+        if (clientAgent !== undefined) {
+            headers['X-Client-Agent'] = clientAgent;
         }
 
         return fetch(this.endpoint, {

--- a/test/contentFetcher.test.ts
+++ b/test/contentFetcher.test.ts
@@ -225,14 +225,14 @@ describe('A content fetcher', () => {
         const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)';
 
         const options: FetchOptions = {
-            userAgent: userAgent,
+            clientAgent: userAgent,
         };
 
         fetchMock.mock({
             ...requestMatcher,
             headers: {
                 ...requestMatcher.headers,
-                'User-Agent': userAgent,
+                'X-Client-Agent': userAgent,
             },
             response: content,
         });

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -195,13 +195,13 @@ describe('An evaluator', () => {
             ...requestMatcher,
             headers: {
                 ...requestMatcher.headers,
-                'User-Agent': userAgent,
+                'X-Client-Agent': userAgent,
             },
             response: JSON.stringify(result),
         });
 
         const options: EvaluationOptions = {
-            userAgent: userAgent,
+            clientAgent: userAgent,
         };
 
         await expect(evaluator.evaluate(query, options)).resolves.toBe(result);


### PR DESCRIPTION
## Summary
Use X-Client-Agent instead of User-Agent to avoid confusion.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings