### PR TITLE
Allow using cookies for storing preview tokens

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -47,6 +47,7 @@ export type Configuration = {
     cookie?: {
         clientId?: CookieCacheConfiguration,
         userToken?: CookieCacheConfiguration,
+        previewToken?: CookieCacheConfiguration,
     },
     eventMetadata?: {[key: string]: string},
     eventProcessor?: DependencyResolver<TrackingEventProcessor>,
@@ -120,7 +121,9 @@ export class Container {
     public getPreviewTokenStore(): TokenStore {
         if (this.previewTokenStore === undefined) {
             this.previewTokenStore = new CachedTokenStore(
-                new LocalStorageCache(this.getGlobalBrowserStorage('preview'), 'token'),
+                this.configuration.cookie?.previewToken !== undefined
+                    ? new CookieCache(this.configuration.cookie.previewToken)
+                    : new LocalStorageCache(this.getGlobalBrowserStorage('preview'), 'token'),
             );
         }
 

--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -39,6 +39,7 @@ export type Configuration = Options & {
     cookie?: {
         clientId?: CookieCacheConfiguration,
         userToken?: CookieCacheConfiguration,
+        previewToken?: CookieCacheConfiguration,
     },
 };
 

--- a/src/schema/sdkFacadeSchemas.ts
+++ b/src/schema/sdkFacadeSchemas.ts
@@ -42,6 +42,7 @@ export const sdkFacadeConfigurationSchema = new ObjectType({
             properties: {
                 clientId: cookieOptionsSchema,
                 userToken: cookieOptionsSchema,
+                previewToken: cookieOptionsSchema,
             },
         }),
         preferredLocale: new StringType({

--- a/src/schema/sdkSchemas.ts
+++ b/src/schema/sdkSchemas.ts
@@ -62,6 +62,7 @@ export const sdkConfigurationSchema = new ObjectType({
             properties: {
                 clientId: cookieOptionsSchema,
                 userToken: cookieOptionsSchema,
+                previewToken: cookieOptionsSchema,
             },
         }),
         debug: new BooleanType(),

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -30,6 +30,7 @@ export type Configuration = {
     cookie?: {
         clientId?: CookieCacheConfiguration,
         userToken?: CookieCacheConfiguration,
+        previewToken?: CookieCacheConfiguration,
     },
     eventProcessor?: DependencyResolver<TrackingEventProcessor>,
 };

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -101,7 +101,7 @@ describe('A container', () => {
         expect(Object.values(localStorage)).toContain(token.toString());
     });
 
-    it('should configure token store to use cookies if specified', () => {
+    it('should configure user token store to use cookies if specified', () => {
         const container = new Container({
             ...configuration,
             cookie: {
@@ -124,6 +124,31 @@ describe('A container', () => {
         expect(store.getToken()?.toString()).toBe(token.toString());
 
         expect(document.cookie).toBe(`croct.token=${token.toString()}`);
+    });
+
+    it('should configure the preview token store to use cookies if specified', () => {
+        const container = new Container({
+            ...configuration,
+            cookie: {
+                previewToken: {
+                    name: 'croct.preview',
+                },
+            },
+        });
+
+        const store = container.getPreviewTokenStore();
+
+        expect(document.cookie).toBe('');
+
+        expect(store.getToken()).toBeNull();
+
+        const token = Token.issue(configuration.appId);
+
+        store.setToken(token);
+
+        expect(store.getToken()?.toString()).toBe(token.toString());
+
+        expect(document.cookie).toBe(`croct.preview=${token.toString()}`);
     });
 
     it('should load the tracker only once', () => {

--- a/test/schemas/sdkFacadeSchemas.test.ts
+++ b/test/schemas/sdkFacadeSchemas.test.ts
@@ -78,6 +78,13 @@ describe('The SDK facade configuration schema', () => {
                     secure: true,
                     sameSite: 'strict',
                 },
+                previewToken: {
+                    name: 'ptk',
+                    domain: 'croct.com',
+                    path: '/',
+                    secure: true,
+                    sameSite: 'strict',
+                },
             },
         }],
     ])('should allow %s', value => {
@@ -240,6 +247,17 @@ describe('The SDK facade configuration schema', () => {
                 },
             },
             "Expected value of type string at path '/cookie/userToken/name', actual null.",
+        ],
+        [
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                cookie: {
+                    previewToken: {
+                        name: null,
+                    },
+                },
+            },
+            "Expected value of type string at path '/cookie/previewToken/name', actual null.",
         ],
     ])('should not allow %s', (value: Record<string, unknown>, message: string) => {
         function validate(): void {

--- a/test/schemas/sdkSchemas.test.ts
+++ b/test/schemas/sdkSchemas.test.ts
@@ -242,6 +242,14 @@ describe('The SDK configuration schema', () => {
                     sameSite: 'strict',
                     maxAge: 0,
                 },
+                previewToken: {
+                    name: 'pt',
+                    domain: 'example.com',
+                    path: '/',
+                    secure: true,
+                    sameSite: 'strict',
+                    maxAge: 0,
+                },
             },
             eventProcessor: jest.fn(),
         }],
@@ -447,6 +455,26 @@ describe('The SDK configuration schema', () => {
                 },
             },
             "Expected at least 1 character at path '/cookie/userToken/name', actual 0.",
+        ],
+        [
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                disableCidMirroring: true,
+                debug: true,
+                test: true,
+                cookie: {
+                    previewToken: {
+                        name: '',
+                        domain: 'example.com',
+                        path: '/',
+                        secure: true,
+                        sameSite: 'strict',
+                        maxAge: 0,
+                    },
+                },
+            },
+            "Expected at least 1 character at path '/cookie/previewToken/name', actual 0.",
         ],
         [
             {


### PR DESCRIPTION
## Summary
This PR adds support for using cookies to store tokens.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings