### PR TITLE
Ensure requests use `cors` mode on browsers

### DIFF
--- a/src/contentFetcher.ts
+++ b/src/contentFetcher.ts
@@ -248,6 +248,13 @@ export class ContentFetcher {
         }
 
         return fetch(dynamic ? this.dynamicEndpoint : this.staticEndpoint, {
+            // Set the request mode to 'cors' when running in the browser.
+            // By default, the request mode is computed based on the referrer policy
+            // and response-tainting rules applied to the script that ultimately
+            // initiated the fetch, make this prone to errors due to unrelated
+            // configurations on the page.
+            // https://fetch.spec.whatwg.org/#origin-header
+            mode: typeof window === 'undefined' ? undefined : 'cors',
             credentials: 'omit',
             ...options.extra,
             method: 'POST',

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -276,6 +276,13 @@ export class Evaluator {
         }
 
         return fetch(this.endpoint, {
+            // Set the request mode to 'cors' when running in the browser.
+            // By default, the request mode is computed based on the referrer policy
+            // and response-tainting rules applied to the script that ultimately
+            // initiated the fetch, make this prone to errors due to unrelated
+            // configurations on the page.
+            // https://fetch.spec.whatwg.org/#origin-header
+            mode: typeof window === 'undefined' ? undefined : 'cors',
             credentials: 'omit',
             ...options.extra,
             method: 'POST',

--- a/test/contentFetcher.test.ts
+++ b/test/contentFetcher.test.ts
@@ -33,6 +33,7 @@ describe('A content fetcher', () => {
     };
 
     const requestMatcher: MockOptions = {
+        functionMatcher: (_, req) => req.mode === 'cors',
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -36,6 +36,7 @@ describe('An evaluator', () => {
 
     const query = 'user\'s name';
     const requestMatcher: MockOptions = {
+        functionMatcher: (_, req) => req.mode === 'cors',
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

Change `ContentFetcher` and `Evaluator` to ensure `cors` request mode when running on a browser. This is necessary for requests to include the `Origin` header[^1] (and therefore participate correctly on the CORS protocol) without relying on the security configurations of the surrounding script/page.

[^1]: https://fetch.spec.whatwg.org/#origin-header

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings