### PR TITLE
Add cookie default options

### DIFF
--- a/src/cache/cookieCache.ts
+++ b/src/cache/cookieCache.ts
@@ -12,12 +12,12 @@ export type CookieCacheConfiguration = {
 export class CookieCache implements Cache {
     private readonly config: CookieCacheConfiguration;
 
-    public constructor(config: CookieCacheConfiguration) {
+    public constructor(config: CookieCacheConfiguration, defaultSecure = window.location.protocol === 'https:') {
         this.config = {
             ...config,
             path: config.path ?? '/',
-            secure: config.secure ?? true,
-            sameSite: config.sameSite ?? 'none',
+            secure: config.secure ?? defaultSecure,
+            sameSite: config.sameSite ?? (defaultSecure ? 'none' : 'lax'),
         };
     }
 

--- a/src/cache/cookieCache.ts
+++ b/src/cache/cookieCache.ts
@@ -16,9 +16,15 @@ export class CookieCache implements Cache {
         this.config = {
             ...config,
             path: config.path ?? '/',
-            secure: config.secure ?? defaultSecure,
-            sameSite: config.sameSite ?? (defaultSecure ? 'none' : 'lax'),
         };
+
+        if (defaultSecure && this.config.secure === undefined) {
+            this.config.secure = true;
+        }
+
+        if (this.config.secure === true && this.config.sameSite === undefined) {
+            this.config.sameSite = 'none';
+        }
     }
 
     public get(): string | null {

--- a/src/cache/cookieCache.ts
+++ b/src/cache/cookieCache.ts
@@ -13,7 +13,12 @@ export class CookieCache implements Cache {
     private readonly config: CookieCacheConfiguration;
 
     public constructor(config: CookieCacheConfiguration) {
-        this.config = config;
+        this.config = {
+            ...config,
+            path: config.path ?? '/',
+            secure: config.secure ?? true,
+            sameSite: config.sameSite ?? 'none',
+        };
     }
 
     public get(): string | null {

--- a/test/cache/cookieCache.test.ts
+++ b/test/cache/cookieCache.test.ts
@@ -28,34 +28,83 @@ describe('A cookie cache', () => {
     });
 
     type DefaultOptionsScenario = {
-        secure?: boolean,
-        options: {
+        https?: boolean,
+        options: Partial<CookieCacheConfiguration>,
+        expectedOptions: {
             Secure?: boolean,
-            SameSite: 'Strict' | 'Lax' | 'None',
+            SameSite?: 'Strict' | 'Lax' | 'None',
         },
     };
 
     it.each<DefaultOptionsScenario>([
         {
-            secure: true,
-            options: {
+            https: true,
+            options: {},
+            expectedOptions: {
                 Secure: true,
                 SameSite: 'None',
             },
         },
         {
-            secure: false,
+            https: true,
             options: {
+                secure: false,
+            },
+            expectedOptions: {
+            },
+        },
+        {
+            https: false,
+            options: {},
+            expectedOptions: {
+            },
+        },
+        {
+            https: false,
+            options: {
+                secure: true,
+            },
+            expectedOptions: {
+                Secure: true,
+                SameSite: 'None',
+            },
+        },
+        {
+            https: true,
+            options: {
+                sameSite: 'lax',
+            },
+            expectedOptions: {
+                Secure: true,
                 SameSite: 'Lax',
             },
         },
         {
+            https: false,
             options: {
-                SameSite: 'Lax',
+                sameSite: 'none',
+            },
+            expectedOptions: {
+                SameSite: 'None',
             },
         },
-    ])('should use default values for missing configuration (secure: $secure)', ({secure, options}) => {
-        const cache = new CookieCache({name: 'cid'}, secure);
+        {
+            https: false,
+            options: {
+                secure: false,
+            },
+            expectedOptions: {
+            },
+        },
+        {
+            https: undefined,
+            options: {},
+            expectedOptions: {
+            },
+        },
+    ])('should use default values for missing configuration (https: $https, options: $options)', scenario => {
+        const {https, options, expectedOptions} = scenario;
+        const cache = new CookieCache({name: 'cid', ...options}, https);
 
         let jar = '';
 
@@ -78,7 +127,7 @@ describe('A cookie cache', () => {
         expect(cookie).toEqual({
             cid: 'foo',
             Path: '/',
-            ...options,
+            ...expectedOptions,
         });
     });
 

--- a/test/cache/cookieCache.test.ts
+++ b/test/cache/cookieCache.test.ts
@@ -27,6 +27,39 @@ describe('A cookie cache', () => {
         expect(cache.get()).toBe('foo');
     });
 
+    it('should use default values for missing configuration', () => {
+        const cache = new CookieCache({
+            name: 'cid',
+        });
+
+        expect(cache.get()).toBeNull();
+
+        let jar = '';
+
+        jest.spyOn(document, 'cookie', 'set').mockImplementation(value => {
+            jar = value;
+        });
+
+        cache.put('foo');
+
+        expect(jar).not.toBeEmpty();
+
+        const cookie: Record<string, string> = {};
+
+        for (const entry of jar.split(';')) {
+            const [name, value = ''] = entry.split('=');
+
+            cookie[decodeURIComponent(name).trim()] = decodeURIComponent(value.trim());
+        }
+
+        expect(cookie).toEqual({
+            cid: 'foo',
+            Path: '/',
+            SameSite: 'None',
+            Secure: '',
+        });
+    });
+
     it('should cache a value using the provided configuration', () => {
         const cache = new CookieCache({
             name: 'cookie name',


### PR DESCRIPTION
## Summary

This PR changes the cookies to use a `sameSite` from `strict` to `none` as it currently causes regeneration of client IDs for users accessing the application from external domains, which also affects the preview link.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings