### PR TITLE
Remove event occurred properties

### DIFF
--- a/src/schema/eventSchemas.ts
+++ b/src/schema/eventSchemas.ts
@@ -114,22 +114,6 @@ export const eventOccurred = new ObjectType({
             minLength: 1,
             maxLength: 50,
         }),
-        testId: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
-        groupId: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
-        personalizationId: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
-        audience: new StringType({
-            minLength: 1,
-            maxLength: 50,
-        }),
         details: new ObjectType({
             additionalProperties: new UnionType(
                 new NullType(),

--- a/src/trackingEvents.ts
+++ b/src/trackingEvents.ts
@@ -325,10 +325,6 @@ export interface PostViewed extends BaseEvent {
 export interface EventOccurred extends BaseEvent {
     type: 'eventOccurred';
     name: string;
-    testId?: string;
-    groupId?: string;
-    personalizationId?: string;
-    audience?: string;
     details?: {[key: string]: string|number|boolean|null};
 }
 

--- a/test/facade/trackerFacade.test.ts
+++ b/test/facade/trackerFacade.test.ts
@@ -232,10 +232,6 @@ describe('A tracker facade', () => {
             {
                 type: 'eventOccurred',
                 name: 'event-name',
-                personalizationId: 'foo',
-                audience: 'bar',
-                testId: 'baz',
-                groupId: 'barbaz',
                 details: {
                     foo: 'bar',
                 },

--- a/test/schemas/eventSchemas.test.ts
+++ b/test/schemas/eventSchemas.test.ts
@@ -215,10 +215,6 @@ describe('The "eventOccurred" payload schema', () => {
         }],
         [{
             name: 'event-name',
-            personalizationId: 'foo',
-            audience: 'bar',
-            testId: 'baz',
-            groupId: 'barbaz',
             details: {
                 number: 10,
                 null: null,
@@ -250,54 +246,6 @@ describe('The "eventOccurred" payload schema', () => {
         [
             {name: null},
             'Expected value of type string at path \'/name\', actual null.',
-        ],
-        [
-            {name: 'foo', personalizationId: ''},
-            'Expected at least 1 character at path \'/personalizationId\', actual 0.',
-        ],
-        [
-            {name: 'foo', personalizationId: 'x'.repeat(51)},
-            'Expected at most 50 characters at path \'/personalizationId\', actual 51.',
-        ],
-        [
-            {name: 'foo', personalizationId: null},
-            'Expected value of type string at path \'/personalizationId\', actual null.',
-        ],
-        [
-            {name: 'foo', audience: ''},
-            'Expected at least 1 character at path \'/audience\', actual 0.',
-        ],
-        [
-            {name: 'foo', audience: 'x'.repeat(51)},
-            'Expected at most 50 characters at path \'/audience\', actual 51.',
-        ],
-        [
-            {name: 'foo', audience: null},
-            'Expected value of type string at path \'/audience\', actual null.',
-        ],
-        [
-            {name: 'foo', testId: ''},
-            'Expected at least 1 character at path \'/testId\', actual 0.',
-        ],
-        [
-            {name: 'foo', testId: 'x'.repeat(51)},
-            'Expected at most 50 characters at path \'/testId\', actual 51.',
-        ],
-        [
-            {name: 'foo', testId: null},
-            'Expected value of type string at path \'/testId\', actual null.',
-        ],
-        [
-            {name: 'foo', groupId: ''},
-            'Expected at least 1 character at path \'/groupId\', actual 0.',
-        ],
-        [
-            {name: 'foo', groupId: 'x'.repeat(51)},
-            'Expected at most 50 characters at path \'/groupId\', actual 51.',
-        ],
-        [
-            {name: 'foo', groupId: null},
-            'Expected value of type string at path \'/groupId\', actual null.',
         ],
         [
             {name: 'foo', details: null},

--- a/test/tracker.test.ts
+++ b/test/tracker.test.ts
@@ -1204,10 +1204,6 @@ describe('A tracker', () => {
             {
                 type: 'eventOccurred',
                 name: 'event-name',
-                personalizationId: 'foo',
-                audience: 'bar',
-                testId: 'baz',
-                groupId: 'barbaz',
                 details: {
                     foo: 'bar',
                 },


### PR DESCRIPTION
## Summary

This PR will remove the "personalizationId", "audience", "testId" and "groupId" properties from the eventOccurred schema

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings