### PR TITLE
Add support for configuring a default global timeout

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -50,6 +50,7 @@ export type Configuration = {
     },
     eventMetadata?: {[key: string]: string},
     eventProcessor?: DependencyResolver<TrackingEventProcessor>,
+    defaultFetchTimeout?: number,
 };
 
 export class Container {
@@ -98,6 +99,7 @@ export class Container {
             appId: this.configuration.appId,
             baseEndpointUrl: this.configuration.evaluationBaseEndpointUrl,
             logger: this.getLogger('Evaluator'),
+            defaultTimeout: this.configuration.defaultFetchTimeout,
         });
     }
 
@@ -114,6 +116,7 @@ export class Container {
             appId: this.configuration.appId,
             baseEndpointUrl: this.configuration.contentBaseEndpointUrl,
             logger: this.getLogger('ContentFetcher'),
+            defaultTimeout: this.configuration.defaultFetchTimeout,
         });
     }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -53,9 +53,9 @@ export type Configuration = {
     defaultFetchTimeout?: number,
 };
 
-const defaultFetchTimeout = 5000;
-
 export class Container {
+    public static readonly DEFAULT_FETCH_TIMEOUT = 5_000; // 5 seconds
+
     private readonly configuration: Configuration;
 
     private context?: Context;
@@ -101,7 +101,7 @@ export class Container {
             appId: this.configuration.appId,
             baseEndpointUrl: this.configuration.evaluationBaseEndpointUrl,
             logger: this.getLogger('Evaluator'),
-            defaultTimeout: this.configuration.defaultFetchTimeout ?? defaultFetchTimeout,
+            defaultTimeout: this.configuration.defaultFetchTimeout ?? Container.DEFAULT_FETCH_TIMEOUT,
         });
     }
 
@@ -118,7 +118,7 @@ export class Container {
             appId: this.configuration.appId,
             baseEndpointUrl: this.configuration.contentBaseEndpointUrl,
             logger: this.getLogger('ContentFetcher'),
-            defaultTimeout: this.configuration.defaultFetchTimeout ?? defaultFetchTimeout,
+            defaultTimeout: this.configuration.defaultFetchTimeout ?? Container.DEFAULT_FETCH_TIMEOUT,
         });
     }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -53,6 +53,8 @@ export type Configuration = {
     defaultFetchTimeout?: number,
 };
 
+const defaultFetchTimeout = 5000;
+
 export class Container {
     private readonly configuration: Configuration;
 
@@ -99,7 +101,7 @@ export class Container {
             appId: this.configuration.appId,
             baseEndpointUrl: this.configuration.evaluationBaseEndpointUrl,
             logger: this.getLogger('Evaluator'),
-            defaultTimeout: this.configuration.defaultFetchTimeout,
+            defaultTimeout: this.configuration.defaultFetchTimeout ?? defaultFetchTimeout,
         });
     }
 
@@ -116,7 +118,7 @@ export class Container {
             appId: this.configuration.appId,
             baseEndpointUrl: this.configuration.contentBaseEndpointUrl,
             logger: this.getLogger('ContentFetcher'),
-            defaultTimeout: this.configuration.defaultFetchTimeout,
+            defaultTimeout: this.configuration.defaultFetchTimeout ?? defaultFetchTimeout,
         });
     }
 

--- a/src/contentFetcher.ts
+++ b/src/contentFetcher.ts
@@ -77,11 +77,13 @@ export type Configuration = {
     apiKey?: string|ApiKey,
     baseEndpointUrl?: string,
     logger?: Logger,
+    defaultTimeout?: number,
 };
 
 type InternalConfiguration = {
     appId?: string,
     apiKey?: string,
+    defaultTimeout?: number,
 };
 
 export class ContentFetcher {
@@ -114,6 +116,7 @@ export class ContentFetcher {
         this.configuration = {
             appId: configuration.appId,
             apiKey: apiKey,
+            defaultTimeout: configuration.defaultTimeout,
         };
     }
 
@@ -124,14 +127,15 @@ export class ContentFetcher {
 
         return new Promise((resolve, reject) => {
             const abortController = new AbortController();
+            const timeout = options.timeout ?? this.configuration.defaultTimeout;
 
-            if (options.timeout !== undefined) {
+            if (timeout !== undefined) {
                 setTimeout(
                     () => {
                         const response: ErrorResponse = {
                             title: 'Maximum timeout reached before content could be loaded.',
                             type: ContentErrorType.TIMEOUT,
-                            detail: `The content took more than ${options.timeout}ms to load.`,
+                            detail: `The content took more than ${timeout}ms to load.`,
                             status: 408, // Request Timeout
                         };
 
@@ -141,7 +145,7 @@ export class ContentFetcher {
 
                         reject(new ContentError(response));
                     },
-                    options.timeout,
+                    timeout,
                 );
             }
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -95,11 +95,13 @@ export type Configuration = {
     apiKey?: string|ApiKey,
     baseEndpointUrl?: string,
     logger?: Logger,
+    defaultTimeout?: number,
 };
 
 type InternalConfiguration = {
     appId?: string,
     apiKey?: string,
+    defaultTimeout?: number,
 };
 
 export class Evaluator {
@@ -129,6 +131,7 @@ export class Evaluator {
         this.configuration = {
             appId: configuration.appId,
             apiKey: apiKey,
+            defaultTimeout: configuration.defaultTimeout,
         };
     }
 
@@ -161,14 +164,15 @@ export class Evaluator {
 
         return new Promise((resolve, reject) => {
             const abortController = new AbortController();
+            const timeout = options.timeout ?? this.configuration.defaultTimeout;
 
-            if (options.timeout !== undefined) {
+            if (timeout !== undefined) {
                 setTimeout(
                     () => {
                         const response: ErrorResponse = {
                             title: 'Maximum evaluation timeout reached before evaluation could complete.',
                             type: EvaluationErrorType.TIMEOUT,
-                            detail: `The evaluation took more than ${options.timeout}ms to complete.`,
+                            detail: `The evaluation took more than ${timeout}ms to complete.`,
                             status: 408, // Request Timeout
                         };
 
@@ -178,7 +182,7 @@ export class Evaluator {
 
                         reject(new EvaluationError(response));
                     },
-                    options.timeout,
+                    timeout,
                 );
             }
 

--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -41,6 +41,7 @@ export type Configuration = Options & {
         userToken?: CookieCacheConfiguration,
         previewToken?: CookieCacheConfiguration,
     },
+    defaultFetchTimeout?: number,
 };
 
 function validateConfiguration(configuration: unknown): asserts configuration is Configuration {

--- a/src/schema/sdkFacadeSchemas.ts
+++ b/src/schema/sdkFacadeSchemas.ts
@@ -1,4 +1,12 @@
-import {ObjectType, StringType, BooleanType, UnionType, NullType, FunctionType} from '../validation';
+import {
+    ObjectType,
+    StringType,
+    BooleanType,
+    UnionType,
+    NullType,
+    FunctionType,
+    NumberType,
+} from '../validation';
 import {tokenScopeSchema} from './contextSchemas';
 import {cookieOptionsSchema, eventMetadataSchema} from './sdkSchemas';
 import {loggerSchema} from './loggerSchema';
@@ -44,6 +52,10 @@ export const sdkFacadeConfigurationSchema = new ObjectType({
                 userToken: cookieOptionsSchema,
                 previewToken: cookieOptionsSchema,
             },
+        }),
+        defaultFetchTimeout: new NumberType({
+            integer: true,
+            minimum: 1,
         }),
         preferredLocale: new StringType({
             pattern: /^[a-z]{2,3}([-_][a-z]{2,3})?$/i,

--- a/src/schema/sdkSchemas.ts
+++ b/src/schema/sdkSchemas.ts
@@ -71,5 +71,9 @@ export const sdkConfigurationSchema = new ObjectType({
         urlSanitizer: new FunctionType(),
         eventMetadata: eventMetadataSchema,
         eventProcessor: new FunctionType(),
+        defaultFetchTimeout: new NumberType({
+            integer: true,
+            minimum: 1,
+        }),
     },
 });

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -33,6 +33,7 @@ export type Configuration = {
         previewToken?: CookieCacheConfiguration,
     },
     eventProcessor?: DependencyResolver<TrackingEventProcessor>,
+    defaultFetchTimeout?: number,
 };
 
 function validateConfiguration(configuration: unknown): asserts configuration is Configuration {

--- a/test/contentFetcher.test.ts
+++ b/test/contentFetcher.test.ts
@@ -48,6 +48,7 @@ describe('A content fetcher', () => {
     afterEach(() => {
         fetchMock.reset();
         jest.clearAllMocks();
+        jest.useRealTimers();
     });
 
     it('should require either an application ID or API key', async () => {
@@ -335,6 +336,8 @@ describe('A content fetcher', () => {
     });
 
     it('should abort after reaching the timeout', async () => {
+        jest.useFakeTimers();
+
         const logger: Logger = {
             debug: jest.fn(),
             info: jest.fn(),
@@ -361,6 +364,8 @@ describe('A content fetcher', () => {
             timeout: 10,
         });
 
+        jest.advanceTimersByTime(11);
+
         const fetchOptions = fetchMock.lastOptions() as MockOptions & {signal: AbortSignal} | undefined;
 
         expect(fetchOptions?.signal).toBeDefined();
@@ -380,6 +385,8 @@ describe('A content fetcher', () => {
     });
 
     it('should use the default timeout if none is specified', async () => {
+        jest.useFakeTimers();
+
         const fetcher = new ContentFetcher({
             appId: appId,
             defaultTimeout: 10,
@@ -394,6 +401,8 @@ describe('A content fetcher', () => {
         });
 
         const promise = fetcher.fetch(contentId);
+
+        jest.advanceTimersByTime(11);
 
         await expect(promise).rejects.toThrow(ContentError);
 

--- a/test/contentFetcher.test.ts
+++ b/test/contentFetcher.test.ts
@@ -349,7 +349,7 @@ describe('A content fetcher', () => {
             appId: appId,
             logger: logger,
             // Ensure the specified timeout has precedence over the default timeout
-            defaultTimeout: 10,
+            defaultTimeout: 15,
         });
 
         fetchMock.mock({

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -49,6 +49,7 @@ describe('An evaluator', () => {
     };
 
     afterEach(() => {
+        jest.useRealTimers();
         fetchMock.reset();
         jest.clearAllMocks();
     });
@@ -257,6 +258,8 @@ describe('An evaluator', () => {
     });
 
     it('should abort the evaluation if the timeout is reached', async () => {
+        jest.useFakeTimers();
+
         const logger: Logger = {
             debug: jest.fn(),
             info: jest.fn(),
@@ -283,6 +286,8 @@ describe('An evaluator', () => {
             timeout: 10,
         });
 
+        jest.advanceTimersByTime(10);
+
         const fetchOptions = fetchMock.lastOptions() as MockOptions & {signal: AbortSignal} | undefined;
 
         expect(fetchOptions?.signal).toBeDefined();
@@ -300,6 +305,8 @@ describe('An evaluator', () => {
     });
 
     it('should use the default timeout if none is specified', async () => {
+        jest.useFakeTimers();
+
         const evaluator = new Evaluator({
             appId: appId,
             defaultTimeout: 10,
@@ -314,6 +321,8 @@ describe('An evaluator', () => {
         });
 
         const promise = evaluator.evaluate(query);
+
+        jest.advanceTimersByTime(10);
 
         await expect(promise).rejects.toThrow(EvaluationError);
         await expect(promise).rejects.toHaveProperty('response', {

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -271,7 +271,7 @@ describe('An evaluator', () => {
             appId: appId,
             logger: logger,
             // Ensure the specified timeout has precedence over the default timeout
-            defaultTimeout: 10,
+            defaultTimeout: 15,
         });
 
         fetchMock.mock({

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -118,6 +118,7 @@ describe('A SDK facade', () => {
             token: Token.issue(appId, 'c4r0l').toString(),
             logger: logger,
             urlSanitizer: urlSanitizer,
+            defaultFetchTimeout: 5,
         });
 
         expect(initialize).toHaveBeenCalledWith(
@@ -132,6 +133,7 @@ describe('A SDK facade', () => {
                 logger: logger,
                 urlSanitizer: urlSanitizer,
                 eventProcessor: expect.any(Function),
+                defaultFetchTimeout: 5,
             } satisfies ResolvedConfiguration,
         );
     });

--- a/test/schemas/sdkFacadeSchemas.test.ts
+++ b/test/schemas/sdkFacadeSchemas.test.ts
@@ -86,6 +86,7 @@ describe('The SDK facade configuration schema', () => {
                     sameSite: 'strict',
                 },
             },
+            defaultFetchTimeout: 1000,
         }],
     ])('should allow %s', value => {
         function validate(): void {
@@ -258,6 +259,13 @@ describe('The SDK facade configuration schema', () => {
                 },
             },
             "Expected value of type string at path '/cookie/previewToken/name', actual null.",
+        ],
+        [
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                defaultFetchTimeout: 0,
+            },
+            'Expected a value greater than or equal to 1 at path \'/defaultFetchTimeout\', actual 0.',
         ],
     ])('should not allow %s', (value: Record<string, unknown>, message: string) => {
         function validate(): void {

--- a/test/schemas/sdkSchemas.test.ts
+++ b/test/schemas/sdkSchemas.test.ts
@@ -252,6 +252,7 @@ describe('The SDK configuration schema', () => {
                 },
             },
             eventProcessor: jest.fn(),
+            defaultFetchTimeout: 1000,
         }],
     ])('should allow %s', value => {
         function validate(): void {
@@ -486,6 +487,17 @@ describe('The SDK configuration schema', () => {
                 eventProcessor: null,
             },
             "Expected value of type function at path '/eventProcessor', actual null.",
+        ],
+        [
+            {
+                appId: '7e9d59a9-e4b3-45d4-b1c7-48287f1e5e8a',
+                tokenScope: 'global',
+                disableCidMirroring: true,
+                debug: true,
+                test: true,
+                defaultFetchTimeout: 0,
+            },
+            "Expected a value greater than or equal to 1 at path '/defaultFetchTimeout', actual 0.",
         ],
     ])('should not allow %s', (value: Record<string, unknown>, message: string) => {
         function validate(): void {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -33,6 +33,7 @@ describe('A SDK', () => {
         baseEndpointUrl: 'https://localtest',
         cidAssignerEndpointUrl: 'https://localtest/cid',
         cookie: {},
+        defaultFetchTimeout: 1000,
     };
 
     beforeEach(() => {
@@ -451,6 +452,37 @@ describe('A SDK', () => {
             await expect(promise).resolves.toBe(result);
         },
     );
+
+    it('should configure the content fetcher with the default timeout', async () => {
+        const slotId = 'home-banner';
+        const result: FetchResponse = {
+            content: {
+                title: 'Hello world',
+            },
+        };
+
+        fetchMock.mock({
+            method: 'GET',
+            matcher: configuration.cidAssignerEndpointUrl,
+            response: '123',
+        });
+
+        fetchMock.mock({
+            method: 'POST',
+            matcher: `begin:${configuration.baseEndpointUrl}`,
+            delay: 200,
+            response: result,
+        });
+
+        const sdk = Sdk.init({
+            ...configuration,
+            defaultFetchTimeout: 5,
+        });
+
+        const promise = sdk.contentFetcher.fetch(slotId);
+
+        await expect(promise).rejects.toThrow('Maximum timeout reached before content could be loaded.');
+    });
 
     it.each([
         [undefined, BASE_ENDPOINT_URL],

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -6,7 +6,7 @@ import {Token} from '../src/token';
 import {TabEventEmulator} from './utils/tabEventEmulator';
 
 import {BeaconPayload, NothingChanged} from '../src/trackingEvents';
-import {FetchResponse} from '../src/contentFetcher';
+import {ContentError, ErrorResponse, FetchResponse} from '../src/contentFetcher';
 import {BASE_ENDPOINT_URL} from '../src/constants';
 
 jest.mock(
@@ -42,6 +42,7 @@ describe('A SDK', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        jest.useRealTimers();
         tabEventEmulator.reset();
         fetchMock.reset();
         localStorage.clear();
@@ -453,7 +454,9 @@ describe('A SDK', () => {
         },
     );
 
-    it('should configure the content fetcher with the default timeout', async () => {
+    it('should configure the content fetcher with the specified default timeout', async () => {
+        jest.useFakeTimers();
+
         const slotId = 'home-banner';
         const result: FetchResponse = {
             content: {
@@ -481,7 +484,57 @@ describe('A SDK', () => {
 
         const promise = sdk.contentFetcher.fetch(slotId);
 
-        await expect(promise).rejects.toThrow('Maximum timeout reached before content could be loaded.');
+        jest.advanceTimersByTime(6);
+
+        await expect(promise).rejects.toThrowWithMessage(
+            ContentError,
+            'Maximum timeout reached before content could be loaded.',
+        );
+
+        await expect(promise).rejects.toHaveProperty('response', expect.objectContaining({
+            detail: 'The content took more than 5ms to load.',
+        } satisfies Partial<ErrorResponse>));
+    });
+
+    it('should configure the content fetcher with the default timeout', async () => {
+        jest.useFakeTimers();
+
+        const slotId = 'home-banner';
+        const result: FetchResponse = {
+            content: {
+                title: 'Hello world',
+            },
+        };
+
+        fetchMock.mock({
+            method: 'GET',
+            matcher: configuration.cidAssignerEndpointUrl,
+            response: '123',
+        });
+
+        fetchMock.mock({
+            method: 'POST',
+            matcher: `begin:${configuration.baseEndpointUrl}`,
+            delay: 10_000,
+            response: result,
+        });
+
+        const {defaultFetchTimeout: _, ...sdkConfiguration} = configuration;
+
+        const sdk = Sdk.init(sdkConfiguration);
+
+        const promise = sdk.contentFetcher.fetch(slotId);
+
+        jest.advanceTimersByTime(5_001);
+
+        await expect(promise).rejects.toThrowWithMessage(
+            ContentError,
+            'Maximum timeout reached before content could be loaded.',
+        );
+
+        await expect(promise).rejects.toHaveProperty('response', expect.objectContaining({
+            detail: 'The content took more than 5000ms to load.',
+        } satisfies Partial<ErrorResponse>));
     });
 
     it.each([

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -8,6 +8,7 @@ import {BeaconPayload, NothingChanged} from '../src/trackingEvents';
 import {ContentError, ErrorResponse as ContentFetchErrorResponse, FetchResponse} from '../src/contentFetcher';
 import {BASE_ENDPOINT_URL} from '../src/constants';
 import {ErrorResponse as EvaluationErrorResponse, EvaluationError} from '../src/evaluator';
+import {Container} from '../src/container';
 
 jest.mock(
     '../src/constants',
@@ -507,7 +508,7 @@ describe('A SDK', () => {
         fetchMock.mock({
             method: 'POST',
             matcher: `begin:${configuration.baseEndpointUrl}`,
-            delay: 10_000,
+            delay: Container.DEFAULT_FETCH_TIMEOUT * 2,
             response: JSON.stringify(result),
         });
 
@@ -517,7 +518,7 @@ describe('A SDK', () => {
 
         const promise = sdk.evaluator.evaluate(query);
 
-        jest.advanceTimersByTime(5_001);
+        jest.advanceTimersByTime(Container.DEFAULT_FETCH_TIMEOUT + 1);
 
         await expect(promise).rejects.toThrowWithMessage(
             EvaluationError,
@@ -590,7 +591,7 @@ describe('A SDK', () => {
         fetchMock.mock({
             method: 'POST',
             matcher: `begin:${configuration.baseEndpointUrl}`,
-            delay: 10_000,
+            delay: Container.DEFAULT_FETCH_TIMEOUT * 2,
             response: result,
         });
 
@@ -600,7 +601,7 @@ describe('A SDK', () => {
 
         const promise = sdk.contentFetcher.fetch(slotId);
 
-        jest.advanceTimersByTime(5_001);
+        jest.advanceTimersByTime(Container.DEFAULT_FETCH_TIMEOUT + 1);
 
         await expect(promise).rejects.toThrowWithMessage(
             ContentError,

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -4,10 +4,10 @@ import {Sdk, Configuration} from '../src';
 import {NullLogger, Logger} from '../src/logging';
 import {Token} from '../src/token';
 import {TabEventEmulator} from './utils/tabEventEmulator';
-
 import {BeaconPayload, NothingChanged} from '../src/trackingEvents';
-import {ContentError, ErrorResponse, FetchResponse} from '../src/contentFetcher';
+import {ContentError, ErrorResponse as ContentFetchErrorResponse, FetchResponse} from '../src/contentFetcher';
 import {BASE_ENDPOINT_URL} from '../src/constants';
+import {ErrorResponse as EvaluationErrorResponse, EvaluationError} from '../src/evaluator';
 
 jest.mock(
     '../src/constants',
@@ -454,6 +454,81 @@ describe('A SDK', () => {
         },
     );
 
+    it('should configure the evaluator with the specified default timeout', async () => {
+        jest.useFakeTimers();
+
+        const query = '1 + 2';
+        const result = 3;
+
+        fetchMock.mock({
+            method: 'GET',
+            matcher: configuration.cidAssignerEndpointUrl,
+            response: '123',
+        });
+
+        fetchMock.mock({
+            method: 'POST',
+            matcher: `begin:${configuration.baseEndpointUrl}`,
+            delay: 200,
+            response: JSON.stringify(result),
+        });
+
+        const sdk = Sdk.init({
+            ...configuration,
+            defaultFetchTimeout: 5,
+        });
+
+        const promise = sdk.evaluator.evaluate(query);
+
+        jest.advanceTimersByTime(6);
+
+        await expect(promise).rejects.toThrowWithMessage(
+            EvaluationError,
+            'Maximum evaluation timeout reached before evaluation could complete.',
+        );
+
+        await expect(promise).rejects.toHaveProperty('response', expect.objectContaining({
+            detail: 'The evaluation took more than 5ms to complete.',
+        } satisfies Partial<EvaluationErrorResponse>));
+    });
+
+    it('should configure the evaluator with the default timeout', async () => {
+        jest.useFakeTimers();
+
+        const query = '1 + 2';
+        const result = 3;
+
+        fetchMock.mock({
+            method: 'GET',
+            matcher: configuration.cidAssignerEndpointUrl,
+            response: '123',
+        });
+
+        fetchMock.mock({
+            method: 'POST',
+            matcher: `begin:${configuration.baseEndpointUrl}`,
+            delay: 10_000,
+            response: JSON.stringify(result),
+        });
+
+        const {defaultFetchTimeout: _, ...sdkConfiguration} = configuration;
+
+        const sdk = Sdk.init(sdkConfiguration);
+
+        const promise = sdk.evaluator.evaluate(query);
+
+        jest.advanceTimersByTime(5_001);
+
+        await expect(promise).rejects.toThrowWithMessage(
+            EvaluationError,
+            'Maximum evaluation timeout reached before evaluation could complete.',
+        );
+
+        await expect(promise).rejects.toHaveProperty('response', expect.objectContaining({
+            detail: 'The evaluation took more than 5000ms to complete.',
+        } satisfies Partial<EvaluationErrorResponse>));
+    });
+
     it('should configure the content fetcher with the specified default timeout', async () => {
         jest.useFakeTimers();
 
@@ -493,7 +568,7 @@ describe('A SDK', () => {
 
         await expect(promise).rejects.toHaveProperty('response', expect.objectContaining({
             detail: 'The content took more than 5ms to load.',
-        } satisfies Partial<ErrorResponse>));
+        } satisfies Partial<ContentFetchErrorResponse>));
     });
 
     it('should configure the content fetcher with the default timeout', async () => {
@@ -534,7 +609,7 @@ describe('A SDK', () => {
 
         await expect(promise).rejects.toHaveProperty('response', expect.objectContaining({
             detail: 'The content took more than 5000ms to load.',
-        } satisfies Partial<ErrorResponse>));
+        } satisfies Partial<ContentFetchErrorResponse>));
     });
 
     it.each([


### PR DESCRIPTION
## Summary
This PR introduces support for configuring a default global timeout, enhancing consistency across the Next.js SDK. Previously, while server-side requests could utilize a global timeout, requests made through hooks and components did not, leading to inconsistency. With this update, the global timeout setting will apply across all requests in the Next.js SDK and will be extendable to other SDKs as well. 

The default timeout is set to 5000 milliseconds (5 seconds).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings