### PR TITLE
Fix timeout logging on requests that didn't timeout

### DIFF
--- a/test/contentFetcher.test.ts
+++ b/test/contentFetcher.test.ts
@@ -414,6 +414,36 @@ describe('A content fetcher', () => {
         });
     });
 
+    it('should not log a timeout error message when request completes before the timeout', async () => {
+        jest.useFakeTimers();
+
+        const logger: Logger = {
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const fetcher = new ContentFetcher({
+            appId: appId,
+            logger: logger,
+            defaultTimeout: 10,
+        });
+
+        fetchMock.mock({
+            ...requestMatcher,
+            response: {
+                result: 'Carol',
+            },
+        });
+
+        await fetcher.fetch(slotId);
+
+        jest.advanceTimersByTime(11);
+
+        expect(logger.error).not.toHaveBeenCalled();
+    });
+
     it('should fetch dynamic content using the provided context', async () => {
         const fetcher = new ContentFetcher({
             appId: appId,


### PR DESCRIPTION
## Summary

- The timeout error message was being logged even if the request had already been completed (successfully or not).
- This PR adds the logic to cancel the `setTimeout` registered for a fetch once it is complete.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings