### PR TITLE
Fix timeout logs

### DIFF
--- a/src/contentFetcher.ts
+++ b/src/contentFetcher.ts
@@ -133,6 +133,7 @@ export class ContentFetcher {
         return new Promise<FetchResponse<P>>((resolve, reject) => {
             const abortController = new AbortController();
             const timeout = options.timeout ?? this.configuration.defaultTimeout;
+
             let timer: number | NodeJS.Timeout | undefined;
 
             if (timeout !== undefined) {

--- a/src/contentFetcher.ts
+++ b/src/contentFetcher.ts
@@ -129,14 +129,14 @@ export class ContentFetcher {
         }
 
         // Types for Browser and Node environment
-        let timeoutReference: number | NodeJS.Timeout | undefined;
 
         return new Promise<FetchResponse<P>>((resolve, reject) => {
             const abortController = new AbortController();
             const timeout = options.timeout ?? this.configuration.defaultTimeout;
+            let timer: number | NodeJS.Timeout | undefined;
 
             if (timeout !== undefined) {
-                timeoutReference = setTimeout(
+                timer = setTimeout(
                     () => {
                         const response: ErrorResponse = {
                             title: `Content could not be loaded in time for slot '${slotId}'.`,
@@ -156,6 +156,7 @@ export class ContentFetcher {
             }
 
             this.load(slotId, abortController.signal, options)
+                .finally(() => clearTimeout(timer))
                 .then(response => {
                     const region = response.headers.get('X-Croct-Region');
                     const timing = response.headers.get('X-Croct-Timing');
@@ -192,12 +193,7 @@ export class ContentFetcher {
                         );
                     }
                 });
-        })
-            .finally(() => {
-                // Once the fetch completes, regardless of outcome, cancel the timeout
-                // to avoid logging an error that didn't happen.
-                clearTimeout(timeoutReference);
-            });
+        });
     }
 
     private load(slotId: string, signal: AbortSignal, options: FetchOptions): Promise<Response> {

--- a/src/contentFetcher.ts
+++ b/src/contentFetcher.ts
@@ -128,7 +128,6 @@ export class ContentFetcher {
             throw new Error('The API key must be provided to fetch static content.');
         }
 
-        // Types for Browser and Node environment
 
         return new Promise<FetchResponse<P>>((resolve, reject) => {
             const abortController = new AbortController();

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -277,9 +277,7 @@ describe('An evaluator', () => {
         fetchMock.mock({
             ...requestMatcher,
             delay: 20,
-            response: {
-                result: 'Carol',
-            },
+            response: JSON.stringify('Carol'),
         });
 
         const promise = evaluator.evaluate(query, {
@@ -315,9 +313,7 @@ describe('An evaluator', () => {
         fetchMock.mock({
             ...requestMatcher,
             delay: 20,
-            response: {
-                result: 'Carol',
-            },
+            response: JSON.stringify('Carol'),
         });
 
         const promise = evaluator.evaluate(query);
@@ -331,6 +327,31 @@ describe('An evaluator', () => {
             detail: 'The evaluation took more than 10ms to complete.',
             status: 408,
         });
+    });
+
+    it('should not log a timeout error message when request completes before the timeout', async () => {
+        jest.useFakeTimers();
+
+        const logger: Logger = {
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+        };
+
+        const evaluator = new Evaluator({
+            appId: appId,
+            logger: logger,
+        });
+
+        fetchMock.mock({
+            ...requestMatcher,
+            response: JSON.stringify('Carol'),
+        });
+
+        await expect(evaluator.evaluate(query, {timeout: 10})).resolves.toBe('Carol');
+
+        expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should evaluate queries using the provided context', async () => {


### PR DESCRIPTION
## Summary
Prevent logging a timeout when the request completes in time.

In addition to clearing the timeout for the evaluation request, I have also moved the logic to immediately follow the completion of the request. This ensures that the timeout only applies to the request logic and not to subsequent actions such as deserialization and logging.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings