### PR TITLE
Change logic to preserve token

### DIFF
--- a/src/facade/sdkFacade.ts
+++ b/src/facade/sdkFacade.ts
@@ -87,12 +87,13 @@ export class SdkFacade {
         );
 
         if (userId !== undefined) {
-            if (userId === null) {
-                sdk.unsetToken();
-            } else {
-                const currentToken = sdk.context.getToken();
+            const currentToken = sdk.context.getToken();
+            const currentSubject = currentToken?.getSubject() ?? null;
 
-                if (currentToken?.getSubject() !== userId) {
+            if (currentSubject !== userId) {
+                if (userId === null) {
+                    sdk.unsetToken();
+                } else {
                     sdk.identify(userId);
                 }
             }

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -1,14 +1,14 @@
 import * as fetchMock from 'fetch-mock';
 import {MockOptions} from 'fetch-mock';
 import {
-    Evaluator,
     ErrorResponse,
     EvaluationContext,
     EvaluationError,
     EvaluationErrorType,
+    EvaluationOptions,
+    Evaluator,
     QueryError,
     QueryErrorResponse,
-    EvaluationOptions,
 } from '../src/evaluator';
 import {Token} from '../src/token';
 import {BASE_ENDPOINT_URL, CLIENT_LIBRARY} from '../src/constants';

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -494,7 +494,7 @@ describe('A SDK facade', () => {
         expect(context.setToken).not.toHaveBeenCalled();
     });
 
-    it('should allow anonymizing a user', () => {
+    it('should allow anonymizing a user passing a null user ID', () => {
         const context = createContextMock();
 
         jest.spyOn(context, 'getToken')
@@ -587,6 +587,7 @@ describe('A SDK facade', () => {
         jest.spyOn(context, 'getToken')
             .mockImplementation()
             .mockImplementation(() => token);
+
         jest.spyOn(context, 'setToken')
             .mockImplementation()
             .mockImplementation(newToken => {

--- a/test/facade/sdkFacade.test.ts
+++ b/test/facade/sdkFacade.test.ts
@@ -494,7 +494,7 @@ describe('A SDK facade', () => {
         expect(context.setToken).not.toHaveBeenCalled();
     });
 
-    it('should allow unidentifying a user', () => {
+    it('should allow anonymizing a user', () => {
         const context = createContextMock();
 
         jest.spyOn(context, 'getToken')
@@ -521,6 +521,62 @@ describe('A SDK facade', () => {
 
         expect(context.setToken).toHaveBeenCalledWith(null);
         expect(context.setToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should preserve the current token if the user is already anonymous', () => {
+        const context = createContextMock();
+
+        jest.spyOn(context, 'getToken')
+            .mockImplementation(() => Token.issue(appId, null));
+
+        jest.spyOn(context, 'setToken')
+            .mockImplementation();
+
+        jest.spyOn(Sdk, 'init')
+            .mockImplementationOnce(config => {
+                const sdk = Sdk.init(config);
+
+                jest.spyOn(sdk, 'appId', 'get').mockReturnValue(appId);
+                jest.spyOn(sdk, 'context', 'get').mockReturnValue(context);
+
+                return sdk;
+            });
+
+        SdkFacade.init({
+            appId: appId,
+            track: false,
+            userId: null,
+        });
+
+        expect(context.setToken).not.toHaveBeenCalled();
+    });
+
+    it('should preserve the current token if the user ID is the same', () => {
+        const context = createContextMock();
+
+        jest.spyOn(context, 'getToken')
+            .mockImplementation(() => Token.issue(appId, 'c4r0l'));
+
+        jest.spyOn(context, 'setToken')
+            .mockImplementation();
+
+        jest.spyOn(Sdk, 'init')
+            .mockImplementationOnce(config => {
+                const sdk = Sdk.init(config);
+
+                jest.spyOn(sdk, 'appId', 'get').mockReturnValue(appId);
+                jest.spyOn(sdk, 'context', 'get').mockReturnValue(context);
+
+                return sdk;
+            });
+
+        SdkFacade.init({
+            appId: appId,
+            track: false,
+            userId: 'c4r0l',
+        });
+
+        expect(context.setToken).not.toHaveBeenCalled();
     });
 
     it('should allow anonymizing a user', () => {


### PR DESCRIPTION
## Summary
Here’s an improved version of your description:

Before this PR, passing userId as null would clear the token, even if the current token was anonymous. This caused issues for organizations with multiple applications, where some use signed tokens and others do not. For those not using signed tokens, passing null would generate an unsigned token, which lacks a token ID and initiates a new session.

With this update, the token is only regenerated if the subject changes. To retain the previous behavior, use token: null instead.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings