### PR TITLE
Include status 401 as retryable on httpBeaconChannel

### DIFF
--- a/src/channel/httpBeaconChannel.ts
+++ b/src/channel/httpBeaconChannel.ts
@@ -122,7 +122,7 @@ export class HttpBeaconChannel implements DuplexChannel<string, Envelope<string,
     }
 
     private static isRetryable(status: number): boolean {
-        // Retry on any server error and client errors 429 (rate limit) and 408 (request timeout)
-        return status >= 500 || status === 429 || status === 408;
+        // Retry on any server error and client errors 429 (rate limit), 408 (request timeout) and 401 (unauthorized)
+        return status >= 500 || status === 429 || status === 408 || status === 401;
     }
 }

--- a/test/channel/httpBeaconChannel.test.ts
+++ b/test/channel/httpBeaconChannel.test.ts
@@ -181,10 +181,6 @@ describe('An HTTP beacon channel', () => {
             log: 'Beacon rejected with non-retryable status: Invalid token',
         },
         {
-            status: 401,
-            title: 'Unauthorized request',
-        },
-        {
             status: 402,
             title: 'Payment overdue',
             log: 'Beacon rejected with non-retryable status: Payment overdue',
@@ -254,6 +250,7 @@ describe('An HTTP beacon channel', () => {
         [408, 'Request timeout'],
         [503, 'Service unavailable'],
         [504, 'Gateway timeout'],
+        [401, 'Unauthorized'],
     ])('should report a retryable error if the response status is %i', async (status, title) => {
         fetchMock.mock(endpointUrl, {
             status: status,


### PR DESCRIPTION
## Summary

This pull request includes changes to the `HttpBeaconChannel` class and its corresponding test suite. The main objective is to update the retry logic to include handling for unauthorized requests (HTTP status code 401).

### Updates to retry logic:

* [`src/channel/httpBeaconChannel.ts`](diffhunk://#diff-e39f5d7c6fac91038c73df75b95a23d6a238aa0d7faa3b7097fb42da294f92d6L125-R126): Modified the `isRetryable` method to include HTTP status code 401 (unauthorized) as a retryable error.

### Updates to test suite:

* [`test/channel/httpBeaconChannel.test.ts`](diffhunk://#diff-22a5b14cf5bc9d155b7d876dc9b9f377886c964002bec5ac16113f430ca70558L183-L186): Removed an existing test case for unauthorized requests and added it to the list of retryable status codes in a different test case. [[1]](diffhunk://#diff-22a5b14cf5bc9d155b7d876dc9b9f377886c964002bec5ac16113f430ca70558L183-L186) [[2]](diffhunk://#diff-22a5b14cf5bc9d155b7d876dc9b9f377886c964002bec5ac16113f430ca70558R253)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings