### PR TITLE
Fix queued channel failure logic

### DIFF
--- a/src/channel/guaranteedChannel.ts
+++ b/src/channel/guaranteedChannel.ts
@@ -99,7 +99,7 @@ export class GuaranteedChannel<M, S> implements OutputChannel<M> {
                     () => {
                         if (this.closed) {
                             // Cancel delay immediately when the channel is closed
-                            abort(MessageDeliveryError.nonRetryable('Connection deliberately closed.'));
+                            abort(MessageDeliveryError.retryable('Connection deliberately closed.'));
                         }
                     },
                     0,

--- a/src/channel/queuedChannel.ts
+++ b/src/channel/queuedChannel.ts
@@ -101,6 +101,10 @@ export class QueuedChannel<T> implements OutputChannel<T> {
             throw error;
         }
 
+        if (this.closed) {
+            throw MessageDeliveryError.retryable('Connection deliberately closed.');
+        }
+
         try {
             const result = await this.channel.publish(message);
 

--- a/src/channel/queuedChannel.ts
+++ b/src/channel/queuedChannel.ts
@@ -84,13 +84,13 @@ export class QueuedChannel<T> implements OutputChannel<T> {
         return this.pending;
     }
 
-    private async chainNext(promise: Promise<void>, message: T, enqueue = false): Promise<void> {
+    private async chainNext(previous: Promise<void>, message: T, enqueue = false): Promise<void> {
         if (enqueue) {
             this.enqueue(message);
         }
 
         try {
-            await promise;
+            await previous;
         } catch (error) {
             if (error instanceof MessageDeliveryError && error.retryable) {
                 // If the previous message failed to deliver, requeue all messages

--- a/src/channel/queuedChannel.ts
+++ b/src/channel/queuedChannel.ts
@@ -46,11 +46,13 @@ export class QueuedChannel<T> implements OutputChannel<T> {
 
         this.enqueue(message);
 
-        this.pending = this.pending.then(
-            () => this.channel
-                .publish(message)
-                .then(this.dequeue.bind(this)),
-        );
+        this.pending = this.pending
+            .catch(() => this.logger.debug('Failed to publish message, skipping...'))
+            .then(
+                () => this.channel
+                    .publish(message)
+                    .then(this.dequeue.bind(this)),
+            );
 
         return this.pending;
     }

--- a/src/channel/queuedChannel.ts
+++ b/src/channel/queuedChannel.ts
@@ -109,9 +109,14 @@ export class QueuedChannel<T> implements OutputChannel<T> {
             return result;
         } catch (error) {
             if (!(error instanceof MessageDeliveryError) || !error.retryable) {
-                // Discard the message if it's non-retryable so that the next message
-                // in the queue can be processed
+                // Discard the message if it's non-retryable
                 this.dequeue();
+
+                if (!enqueue) {
+                    // If the message was not enqueued, suppress the error
+                    // so that the next message in the queue can be immediately
+                    return;
+                }
             }
 
             throw error;

--- a/src/channel/retryChannel.ts
+++ b/src/channel/retryChannel.ts
@@ -42,7 +42,7 @@ export class RetryChannel<T> implements OutputChannel<T> {
 
         while (this.retryPolicy.shouldRetry(attempt, message, error)) {
             if (this.closed) {
-                throw MessageDeliveryError.nonRetryable('Connection deliberately closed.');
+                throw MessageDeliveryError.retryable('Connection deliberately closed.');
             }
 
             const delay = this.retryPolicy.getDelay(attempt);
@@ -59,7 +59,7 @@ export class RetryChannel<T> implements OutputChannel<T> {
                                 // Cancel delay immediately when the channel is closed
                                 window.clearInterval(closeWatcher);
 
-                                reject(MessageDeliveryError.nonRetryable('Connection deliberately closed.'));
+                                reject(MessageDeliveryError.retryable('Connection deliberately closed.'));
                             }
                         },
                         0,

--- a/test/channel/guaranteedChannel.test.ts
+++ b/test/channel/guaranteedChannel.test.ts
@@ -66,7 +66,7 @@ describe('A guaranteed channel', () => {
         await channel.close();
 
         await expect(promise).rejects.toThrowWithMessage(MessageDeliveryError, 'Connection deliberately closed.');
-        await expect(promise).rejects.toHaveProperty('retryable', false);
+        await expect(promise).rejects.toHaveProperty('retryable', true);
     });
 
     it('should close the output channel on close', async () => {

--- a/test/channel/queuedChannel.test.ts
+++ b/test/channel/queuedChannel.test.ts
@@ -208,7 +208,7 @@ describe('A queued channel', () => {
         expect(outputChannel.publish).toHaveBeenNthCalledWith(2, 'bar');
     });
 
-    it('should not require flush for processing re-enqueued messages', async () => {
+    it('should resume processing on re-enqueued message errors', async () => {
         const outputChannel: OutputChannel<string> = {
             close: jest.fn().mockResolvedValue(undefined),
             publish: jest.fn()

--- a/test/channel/retryChannel.test.ts
+++ b/test/channel/retryChannel.test.ts
@@ -76,7 +76,7 @@ describe('A retry channel', () => {
         await channel.close();
 
         await expect(promise).rejects.toThrowWithMessage(MessageDeliveryError, 'Connection deliberately closed.');
-        await expect(promise).rejects.toHaveProperty('retryable', false);
+        await expect(promise).rejects.toHaveProperty('retryable', true);
     });
 
     it('should fail to publish a message if the channel is closed while retrying', async () => {
@@ -96,7 +96,7 @@ describe('A retry channel', () => {
         await channel.close();
 
         await expect(promise).rejects.toThrowWithMessage(MessageDeliveryError, 'Connection deliberately closed.');
-        await expect(promise).rejects.toHaveProperty('retryable', false);
+        await expect(promise).rejects.toHaveProperty('retryable', true);
     });
 
     it('should fail to publish a message if maximum retry attempts is reached', async () => {


### PR DESCRIPTION
## Summary
The current implementation of the queued channel doesn't handle failures, and that went unnoticed before because the old event tracker service just dropped invalid events. Now, with the new service, the SDK has to do the dropping. This change caused downstream channels to report errors to the upstream channel, which wasn't happening before—so this issue surfaced.

Right now, when a message fails, the queue just stops processing until a new event comes in. Since errors aren't being handled, failed messages don't get dequeued, which causes the queue to get stuck and eventually fill up.

This PR fixes that by making sure failed messages are dequeued so the next ones can still be tried.

Also, when the channel was reinitialized, you had to manually call the flush to reenqueue the messages. If you tried to send a message, it would fail and tell you to flush first. Now, it’s been refactored, so if there are pending messages, they’ll automatically get reenqueued before the new message is sent.

Lastly, this PR also makes "Connection deliberately closed" errors retryable since it's part of the regular lifecycle. For example, if the SDK is unplugged while messages are still being sent, it will retry sending them once plugged back in.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings