### PR TITLE
Fix incorrect timeout log on `evaluate` requests

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -170,7 +170,7 @@ export class Evaluator {
             let timer: number | NodeJS.Timeout | undefined;
 
             if (timeout !== undefined) {
-                setTimeout(
+                timer = setTimeout(
                     () => {
                         const response: ErrorResponse = {
                             title: `Evaluation could not be completed in time for query "${reference}".`,

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -351,6 +351,8 @@ describe('An evaluator', () => {
 
         await expect(evaluator.evaluate(query, {timeout: 10})).resolves.toBe('Carol');
 
+        jest.advanceTimersByTime(11);
+
         expect(logger.error).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary

- Assign the timer to the variable so it can be cancelled when the request is completed
- Fix testing to include the time change to avoid regressions

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings