### PR TITLE
Prevent error on concurrent queue processing

### DIFF
--- a/src/channel/queuedChannel.ts
+++ b/src/channel/queuedChannel.ts
@@ -58,7 +58,11 @@ export class QueuedChannel<T> implements OutputChannel<T> {
         this.logger.debug('Dequeuing message...');
         this.logger.debug(`Queue length: ${Math.max(0, this.queue.length() - 1)}`);
 
-        this.queue.shift();
+        if (this.queue.length() === 0) {
+            this.logger.debug('Queue unexpectedly empty, possibly due to concurrent modification.');
+        } else {
+            this.queue.shift();
+        }
     }
 
     private requeue(): Promise<void> {


### PR DESCRIPTION
## Summary

We recently identified an issue where an application embedding a page via an iframe consistently encountered an error:

![Error](https://github.com/user-attachments/assets/589e8ce5-fe7e-47e6-a835-63b6ffe83c21)

After investigation, we traced the root cause to a possible race condition: both the parent page and the iframe were accessing the same event queue concurrently. A proper fix would require a more invasive change, which involves additional planning and discussion.  

Since this is currently considered an edge case, this PR takes a minimal approach, ensuring that if a concurrent modification occurs, a message is logged but no error is thrown, allowing the SDK to continue functioning gracefully.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings