### PR TITLE
Add keepalive configuration

### DIFF
--- a/src/channel/httpBeaconChannel.ts
+++ b/src/channel/httpBeaconChannel.ts
@@ -57,6 +57,7 @@ export class HttpBeaconChannel implements DuplexChannel<string, Envelope<string,
                 originalTime: timestamp,
                 departureTime: Date.now(),
             }),
+            keepalive: true,
         }).then(async response => {
             if (response.ok) {
                 this.notify(receiptId);


### PR DESCRIPTION
## Summary

This PR will add the `keepalive` configuration to the HTTP beacon tracker, this will improve the SDK behavior by ensuring that the browser will keep the request alive even if the associated page is unloaded.

Requests such as those that go to the evaluator or content service don't need this configuration, since they should be ended as soon as the page is unloaded.

### Related Issues

- Closes #470 

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings