### PR TITLE
Fix MAX_QUERY_LENGTH published as NaN

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -6,10 +6,6 @@ on:
       - synchronize
       - opened
 
-env:
-  BASE_ENDPOINT: https://api.croct.io
-  MAX_QUERY_LENGTH: 500
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -33,14 +29,8 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Prepare release
-        run: |-
-          cp LICENSE README.md build/
-          cd build
-          find . -type f -path '*/*\.js.map' -exec sed -i -e "s~../src~src~" {} +          
-          sed -i -e "s~<@version@>~0.0.0-dev~" constants.*
-          sed -i -e "s~<@baseEndpointUrl@>~${BASE_ENDPOINT}~" constants.*
-          sed -i -e "s~parseInt('<@maxQueryLength@>', 10)~${MAX_QUERY_LENGTH}~" constants.*
+      - name: Prepare preview
+        run: node prepare-release.mjs 0.0.0-dev
 
       - name: Publish preview
         run: |-

--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -9,11 +9,4 @@ jobs:
   deploy:
     uses: croct-tech/shared-public-configs/.github/workflows/publish-public-npm-package.yml@master
     with:
-      prepare-script: >-
-        cp LICENSE README.md build/ &&
-        cd build &&
-        find . -type f -path '*/*\.js.map' -exec sed -i -e "s~../src~src~" {} + &&
-        sed -i -e "s~\"version\": \"0.0.0-dev\"~\"version\": \"${GITHUB_REF##*/}\"~" package.json &&
-        sed -i -e "s~<@version@>~${GITHUB_REF##*/}~" constants.* &&
-        sed -i -e "s~<@baseEndpointUrl@>~https://api.croct.io~" constants.* &&
-        sed -i -e "s~parseInt('<@maxQueryLength@>', 10)~500~" constants.*
+      prepare-script: node prepare-release.mjs

--- a/prepare-release.mjs
+++ b/prepare-release.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import {pathToFileURL} from 'url';
+
+const BUILD_DIR = path.resolve('build');
+const PACKAGE_JSON = path.join(BUILD_DIR, 'package.json');
+const ROOT_FILES = ['LICENSE', 'README.md'];
+const PLACEHOLDER_PATTERN = /<@(\w+)@>/g;
+const TEXT_FILE_PATTERN = /\.(?:js|cjs|mjs|ts|cts|mts|json|map)$/;
+
+function getVersion() {
+    const version = process.argv[2] ?? process.env.GITHUB_REF_NAME;
+
+    if (version === undefined || version === '') {
+        throw new Error('The version is missing. Pass it as an argument or set GITHUB_REF_NAME.');
+    }
+
+    return version;
+}
+
+/**
+ * Resolves the values for the `<@placeholder@>` markers declared in `src/constants.ts`.
+ */
+function getConstants(version) {
+    return {
+        baseEndpointUrl: 'https://api.croct.io',
+        maxQueryLength: '500',
+        version: version,
+    };
+}
+
+function findFiles(dir, pattern, fileList = []) {
+    for (const file of fs.readdirSync(dir)) {
+        const filePath = path.join(dir, file);
+
+        if (fs.statSync(filePath).isDirectory()) {
+            findFiles(filePath, pattern, fileList);
+        } else if (pattern.test(file)) {
+            fileList.push(filePath);
+        }
+    }
+
+    return fileList;
+}
+
+function copyRootFiles() {
+    for (const file of ROOT_FILES) {
+        fs.copyFileSync(path.resolve(file), path.join(BUILD_DIR, file));
+    }
+
+    console.log(`✅ Copied ${ROOT_FILES.join(', ')}`);
+}
+
+function updateVersion(version) {
+    const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf-8'));
+
+    pkg.version = version;
+
+    fs.writeFileSync(PACKAGE_JSON, JSON.stringify(pkg, null, 2));
+
+    console.log(`✅ Set version to ${version}`);
+}
+
+function fixSourceMaps() {
+    const maps = findFiles(BUILD_DIR, /\.map$/);
+
+    for (const file of maps) {
+        const content = fs.readFileSync(file, 'utf-8');
+
+        fs.writeFileSync(file, content.replace(/\.\.\/src/g, 'src'));
+    }
+
+    console.log(`✅ Fixed source paths in ${maps.length} source map(s)`);
+}
+
+/**
+ * Replaces the placeholders rather than the expressions around them, so the
+ * substitution does not depend on how the bundler formats the generated code.
+ */
+function replaceConstants(constants) {
+    for (const [name, value] of Object.entries(constants)) {
+        if (typeof value !== 'string' || value === '') {
+            throw new Error(`The constant "${name}" resolved to an empty value.`);
+        }
+    }
+
+    const files = findFiles(BUILD_DIR, /^constants\./);
+
+    if (files.length === 0) {
+        throw new Error('No constants file found in the build directory.');
+    }
+
+    for (const file of files) {
+        const content = fs.readFileSync(file, 'utf-8');
+
+        fs.writeFileSync(
+            file,
+            content.replace(PLACEHOLDER_PATTERN, (placeholder, name) => constants[name] ?? placeholder),
+        );
+    }
+
+    console.log(`✅ Replaced constants in ${files.length} file(s)`);
+}
+
+function checkPlaceholders() {
+    const unresolved = [];
+
+    for (const file of findFiles(BUILD_DIR, TEXT_FILE_PATTERN)) {
+        const matches = fs.readFileSync(file, 'utf-8').matchAll(PLACEHOLDER_PATTERN);
+
+        for (const [placeholder] of matches) {
+            unresolved.push(`${path.relative(BUILD_DIR, file)}: ${placeholder}`);
+        }
+    }
+
+    if (unresolved.length > 0) {
+        throw new Error(`Unresolved placeholders found:\n${unresolved.join('\n')}`);
+    }
+
+    console.log('✅ No unresolved placeholders left');
+}
+
+/**
+ * Checks the values the package actually exports, as a placeholder left behind
+ * has already shipped a `NaN` once.
+ */
+async function checkConstants(version) {
+    const constants = await import(pathToFileURL(path.join(BUILD_DIR, 'constants.js')).href);
+
+    const expectations = {
+        BASE_ENDPOINT_URL: value => typeof value === 'string' && URL.canParse(value),
+        MAX_QUERY_LENGTH: value => Number.isInteger(value) && value > 0,
+        VERSION: value => value === version,
+        CLIENT_LIBRARY: value => typeof value === 'string' && value.includes(version),
+    };
+
+    for (const [name, isValid] of Object.entries(expectations)) {
+        if (!isValid(constants[name])) {
+            throw new Error(`The constant "${name}" is invalid: ${String(constants[name])}`);
+        }
+    }
+
+    console.log(`✅ Exported constants are valid (MAX_QUERY_LENGTH=${constants.MAX_QUERY_LENGTH})`);
+}
+
+async function prepareRelease() {
+    const version = getVersion();
+
+    copyRootFiles();
+    updateVersion(version);
+    fixSourceMaps();
+    replaceConstants(getConstants(version));
+    checkPlaceholders();
+    await checkConstants(version);
+}
+
+await prepareRelease();


### PR DESCRIPTION
## Problem

Every published version of the SDK, including the current `latest` ([0.22.3](https://unpkg.com/@croct/sdk@0.22.3/constants.js)), ships an unresolved placeholder:

```js
const BASE_ENDPOINT_URL = "https://api.croct.io";
const MAX_QUERY_LENGTH = parseInt("<@maxQueryLength@>", 10);   // NaN
const VERSION = "0.22.3";
```

`MAX_QUERY_LENGTH` is therefore `NaN` at runtime. Since `length > NaN` is always false, the guard in `Evaluator.evaluate()` (`src/evaluator.ts:234`) never rejects, so over-long queries are never caught client-side and are sent to the server instead of failing with `TOO_COMPLEX_QUERY`. The placeholder also leaks into the plug-js CDN bundle, which bundles the SDK.

## Cause

The release workflow substituted the placeholder together with the expression around it:

```
sed -i -e "s~parseInt('<@maxQueryLength@>', 10)~500~" constants.*
```

`src/constants.ts` writes that expression with **single** quotes, but esbuild normalizes string literals to **double** quotes in the build output, so the pattern never matched. The `<@version@>` and `<@baseEndpointUrl@>` substitutions replace the placeholder token alone, which is why they worked and this one did not — a sed pattern coupled to generated code that nothing verified.

Reproduced locally by running the workflow's own commands against a fresh build; the output matches the published artifact exactly.

## Fix

Move the prepare step into `prepare-release.mjs`, which replaces the **placeholders themselves** rather than the surrounding code, so substitution no longer depends on how the bundler formats its output.

Two guards, since this shipped silently for every release:

- Fail if any `<@…@>` placeholder survives anywhere in the build output.
- Import the built module and assert the values the package actually **exports** — `MAX_QUERY_LENGTH` must be a positive integer, `VERSION` must match the tag, and so on. A text scan alone would not catch a `NaN` produced by a substituted-but-invalid value.

## Verification

- `MAX_QUERY_LENGTH` now evaluates to `500`; `BASE_ENDPOINT_URL`, `VERSION` and `CLIENT_LIBRARY` unchanged in behaviour.
- Both guards were tested against the real failure modes and exit `1`: a placeholder left unsubstituted (the original bug), and a substituted-but-non-numeric value that would ship `NaN`. A missing version also exits `1`.
- Preview path (`node prepare-release.mjs 0.0.0-dev`) verified, and `tsc --noEmit` passes.

## Notes

The same approach landed in plug-js in croct-tech/plug-js#378, which fixed a related failure where the constants were published empty. Worth applying to the other packages that use this placeholder pattern.

Needs a patch release to reach users.
